### PR TITLE
:wrench: PIC-1497: Added autoscaling

### DIFF
--- a/helm_deploy/court-hearing-event-receiver/values.yaml
+++ b/helm_deploy/court-hearing-event-receiver/values.yaml
@@ -2,8 +2,6 @@
 generic-service:
   nameOverride: court-hearing-event-receiver
 
-  replicaCount: 4
-
   image:
     repository: quay.io/hmpps/court-hearing-event-receiver
     tag: app_version    # override at deployment time

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,6 +1,11 @@
 ---
 generic-service:
-  replicaCount: 2
   ingress:
     host: court-hearing-event-receiver-dev.hmpps.service.justice.gov.uk
     tlsSecretName: court-probation-dev-cert-secret
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 100
+

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,6 +1,10 @@
 ---
 generic-service:
-  replicaCount: 2
   ingress:
     host: court-hearing-event-receiver-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: court-probation-preprod-cert-secret
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 100

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,6 +1,10 @@
 ---
 generic-service:
-  replicaCount: 2
   ingress:
     host: court-hearing-event-receiver.hmpps.service.justice.gov.uk
     tlsSecretName: court-probation-cert-secret
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 100


### PR DESCRIPTION
The generic-service includes the hpa.yaml file and the following default values for autoscaling:

```
autoscaling:
  enabled: false
  minReplicas: 1
  maxReplicas: 100
  targetCPUUtilizationPercentage: 80
```
The values set in values-[environment].yaml override the default values set in the generic-service chart so we can customise autoscaling to suit our needs.
This PR includes adding the values for each environment.