### PR TITLE
🐛 PIC-1496 track court hearing received event

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.3"
   kotlin("plugin.spring") version "1.5.10"
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/TelemetryConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/TelemetryConfig.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config
+
+import com.microsoft.applicationinsights.TelemetryClient
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext
+import com.microsoft.applicationinsights.web.internal.ThreadContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.context.annotation.Conditional
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.core.type.AnnotatedTypeMetadata
+import org.springframework.lang.NonNull
+import org.springframework.web.context.annotation.RequestScope
+import java.util.Optional
+
+@Configuration
+class TelemetryConfig {
+
+  @Bean
+  @Conditional(AppInsightKeyAbsentCondition::class)
+  fun getTelemetryClient(): TelemetryClient {
+    return TelemetryClient()
+  }
+
+  private class AppInsightKeyAbsentCondition : Condition {
+    override fun matches(@NonNull context: ConditionContext, @NonNull metadata: AnnotatedTypeMetadata): Boolean {
+      return StringUtils.isEmpty(context.environment.getProperty("application.insights.ikey"))
+    }
+  }
+
+  @Bean
+  @Profile("!test")
+  @RequestScope
+  fun requestProperties(): Map<String, String> {
+    return Optional.ofNullable(ThreadContext.getRequestTelemetryContext())
+      .map { obj: RequestTelemetryContext -> obj.httpRequestTelemetry }
+      .map { obj: RequestTelemetry -> obj.properties }
+      .orElse(emptyMap())
+  }
+
+  @Bean
+  fun getOperationId(): () -> String? {
+    return { ThreadContext.getRequestTelemetryContext()?.httpRequestTelemetry?.context?.operation?.id }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventController.kt
@@ -11,21 +11,31 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.HearingEvent
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.MessageNotifier
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryEventType
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryService
 
 @Api(value = "Event")
 @RestController
 class EventController(
   @Autowired
-  private val messageNotifier: MessageNotifier
+  private val messageNotifier: MessageNotifier,
+  @Autowired
+  private val telemetryService: TelemetryService
 ) {
 
   @ApiOperation(value = "Endpoint to receive events")
-  @RequestMapping(value = ["/event"], method = [RequestMethod.POST], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @RequestMapping(value = ["/event"], method = [RequestMethod.POST], produces = [MediaType.APPLICATION_JSON_VALUE], consumes = [MediaType.APPLICATION_JSON_VALUE])
   @ResponseStatus(HttpStatus.ACCEPTED)
-  fun postEvent(@RequestBody body: String) {
-    log.info("Received event payload: %s".format(body))
-    messageNotifier.send(body)
+  fun postEvent(@RequestBody hearingEvent: HearingEvent) {
+    log.info("Received hearing event payload id: %s".format(hearingEvent.hearing.id))
+    val hearing = hearingEvent.hearing
+    telemetryService.trackEvent(
+      TelemetryEventType.COURT_HEARING_EVENT_RECEIVED,
+      mapOf("courtCode" to hearing.courtCentre.code, "id" to hearing.id)
+    )
+    messageNotifier.send(hearingEvent)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/CourtCentre.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/CourtCentre.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CourtCentre(
+  val code: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Hearing.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Hearing.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Hearing(
+  val id: String,
+  val courtCentre: CourtCentre,
+  val hearingDays: List<HearingDay>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingDay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingDay.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class HearingDay(
+  val listingSequence: Int
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingEvent.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class HearingEvent(
+  var hearing: Hearing
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageNotifier.kt
@@ -3,29 +3,32 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.MessageAttributeValue
 import com.amazonaws.services.sns.model.PublishRequest
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.HearingEvent
 
 private const val MESSAGE_TYPE = "CP_TEST_COURT_CASE"
 
 @Component
 class MessageNotifier(
   @Autowired
+  private val objectMapper: ObjectMapper,
+  @Autowired
   private val amazonSNSClient: AmazonSNS,
   @Value("\${aws.sns.topic_arn}")
   private val topicArn: String
 ) {
-  fun send(message: String) {
+  fun send(hearingEvent: HearingEvent) {
 
     val messageValue = MessageAttributeValue()
       .withDataType("String")
       .withStringValue(MESSAGE_TYPE)
 
-    val publishRequest = PublishRequest(topicArn, message)
+    val publishRequest = PublishRequest(topicArn, objectMapper.writeValueAsString(hearingEvent))
       .withMessageAttributes(mapOf("messageType" to messageValue))
-
     val publishResult = amazonSNSClient.publish(publishRequest)
     log.info("Published message with message Id {}", publishResult.messageId)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/TelemetryEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/TelemetryEventType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
+
+enum class TelemetryEventType(val eventName: String) {
+  COURT_HEARING_EVENT_RECEIVED("PiCCourtHearingEventReceived")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/TelemetryService.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class TelemetryService(@Autowired private val telemetryClient: TelemetryClient) {
+
+  fun trackEvent(eventType: TelemetryEventType, customDimensions: Map<String, String?>) {
+    telemetryClient.trackEvent(eventType.eventName, customDimensions, null)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
@@ -1,25 +1,48 @@
 package uk.gov.justice.digital.hmpps.courthearingeventreceiver.controller
 
 import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockitokotlin2.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.HearingEvent
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryEventType
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryService
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 @ActiveProfiles("test")
 class EventControllerIntTest : IntegrationTestBase() {
+
+  lateinit var hearingEvent: HearingEvent
+
+  @Autowired
+  lateinit var mapper: ObjectMapper
+
   @Autowired
   lateinit var sqs: AmazonSQSAsync
+
+  @MockBean
+  lateinit var telemetryService: TelemetryService
+
+  @BeforeEach
+  fun beforeEach() {
+    val str = File("src/test/resources/json/court-application-minimal.json").readText(Charsets.UTF_8)
+    hearingEvent = mapper.readValue(str, HearingEvent::class.java)
+  }
 
   @Test
   fun whenPostToEventEndpointWithRequiredRole_thenReturn204NoContent_andPushToTopic() {
 
     postEvent(
-      "foo",
+      hearingEvent,
       jwtHelper.createJwt("common-platform-events", roles = listOf("ROLE_COURT_HEARING_EVENT_WRITE"))
     )
       .exchange()
@@ -29,31 +52,33 @@ class EventControllerIntTest : IntegrationTestBase() {
     val messages = sqs.receiveMessageAsync("http://localhost:4566/000000000000/test-queue")
       .get(5, TimeUnit.SECONDS)
     assertThat(messages.messages.size).isEqualTo(1)
-    assertThat(messages.messages.get(0).body).contains("foo")
+    assertThat(messages.messages[0].body).contains("59cb14a6-e8de-4615-9c9d-94fa5ef81ad2")
+
+    val expectedMap = mapOf("id" to "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2", "courtCode" to "B10JQ00")
+    verify(telemetryService).trackEvent(TelemetryEventType.COURT_HEARING_EVENT_RECEIVED, expectedMap)
   }
 
   @Test
   fun whenPostToEventEndpointWithoutRequiredRole_thenReturn403Forbidden() {
 
-    postEvent("foo", jwtHelper.createJwt("common-platform-events"))
+    postEvent(hearingEvent, jwtHelper.createJwt("common-platform-events"))
       .exchange()
       .expectStatus().isForbidden
   }
 
   @Test
   fun whenPostToEventEndpointWithBadToken_thenReturn401Unauthorized() {
-    val path = "/event"
     val token = "bad_token"
-    postEvent(path, token)
+    postEvent(hearingEvent, token)
       .exchange()
       .expectStatus().isUnauthorized
   }
 
-  private fun postEvent(body: String, token: String) =
+  private fun postEvent(hearingEvent: HearingEvent, token: String) =
     webTestClient
       .post()
       .uri("/event")
       .contentType(MediaType.APPLICATION_JSON)
       .header("Authorization", "Bearer $token")
-      .body(Mono.just(body), String.javaClass)
+      .body(Mono.just(hearingEvent), HearingEvent::class.java)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/TelemetryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/TelemetryServiceTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
+
+import com.microsoft.applicationinsights.TelemetryClient
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+internal class TelemetryServiceTest {
+
+  @Mock
+  private lateinit var telemetryClient: TelemetryClient
+
+  @InjectMocks
+  lateinit var telemetryService: TelemetryService
+  @Test
+  fun `when track event then use customDimensions map`() {
+    val map = mapOf("key" to "value")
+    telemetryService.trackEvent(TelemetryEventType.COURT_HEARING_EVENT_RECEIVED, map)
+
+    verify(telemetryClient).trackEvent("PiCCourtHearingEventReceived", map, null)
+  }
+}

--- a/src/test/resources/json/court-application-minimal.json
+++ b/src/test/resources/json/court-application-minimal.json
@@ -1,0 +1,26 @@
+{
+  "hearing": {
+    "courtCentre": {
+      "address": {
+        "address1": "The Law Courts",
+        "address2": "Alexandra Road",
+        "address3": "Wimbledon",
+        "address4": "",
+        "address5": "",
+        "postcode": "SW19 7JP"
+      },
+      "code": "B10JQ00",
+      "name": "Wimbledon Magistrates' Court",
+      "roomId": "1414ea28-8b0e-3ba7-8f97-f2bb6d5dd38c",
+      "roomName": "Courtroom 05"
+    },
+    "hearingDays": [
+      {
+        "listedDurationMinutes": 1,
+        "listingSequence": 0,
+        "sittingDay": "2021-06-25T09:00:00.000Z"
+      }
+    ],
+    "id": "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2"
+  }
+}

--- a/src/test/resources/json/court-application.json
+++ b/src/test/resources/json/court-application.json
@@ -1,0 +1,347 @@
+{
+  "hearing": {
+    "applicantCounsels": [],
+    "applicationPartyCounsels": [],
+    "approvalsRequested": [],
+    "companyRepresentatives": [],
+    "courtApplicationPartyAttendance": [],
+    "courtApplications": [
+      {
+        "applicant": {
+          "id": "25d3a492-0bf0-4bb2-8aa7-2f084d70a9b2",
+          "masterDefendant": {
+            "defendantCase": [
+              {
+                "caseId": "598a9519-9a0f-4fd0-80de-a2c72a662739",
+                "caseReference": "90GD1000052",
+                "defendantId": "1c052ea0-03a4-4c37-bcce-bd4110508e77"
+              }
+            ],
+            "masterDefendantId": "1c052ea0-03a4-4c37-bcce-bd4110508e77",
+            "personDefendant": {
+              "arrestSummonsNumber": "TFL1",
+              "bailStatus": {
+                "code": "A",
+                "description": "Not applicable",
+                "id": "86009c70-759d-3308-8de4-194886ff9a77"
+              },
+              "personDetails": {
+                "address": {
+                  "address1": "1234",
+                  "address2": "StreetDescription",
+                  "address3": "Locality2O"
+                },
+                "dateOfBirth": "1990-01-01",
+                "documentationLanguageNeeds": "ENGLISH",
+                "firstName": "Darius",
+                "gender": "MALE",
+                "lastName": "ProhaskaOndricka",
+                "title": "Mr"
+              }
+            }
+          },
+          "organisationPersons": []
+        },
+        "applicationParticulars": "Test",
+        "applicationReceivedDate": "2021-06-24",
+        "applicationReference": "90GD1000052",
+        "applicationStatus": "UN_ALLOCATED",
+        "courtApplicationCases": [
+          {
+            "caseStatus": "ACTIVE",
+            "isSJP": false,
+            "offences": [],
+            "prosecutionCaseId": "598a9519-9a0f-4fd0-80de-a2c72a662739",
+            "prosecutionCaseIdentifier": {
+              "prosecutionAuthorityCode": "DERPF",
+              "prosecutionAuthorityId": "bdc190e7-c939-37ca-be4b-9f615d6ef40e",
+              "prosecutionAuthorityName": "Derbyshire Police",
+              "caseURN": "90GD1000052"
+            }
+          }
+        ],
+        "id": "af8b3c0d-8dc7-4ac6-aaf3-5f997996f4b6",
+        "judicialResults": [
+          {
+            "alwaysPublished": false,
+            "category": "FINAL",
+            "d20": false,
+            "excludedFromResults": false,
+            "isAdjournmentResult": false,
+            "isAvailableForCourtExtract": true,
+            "isConvictedResult": false,
+            "isDeleted": false,
+            "isFinancialResult": false,
+            "judicialResultId": "6c6b18e5-2277-4e45-9a43-473301a497bd",
+            "judicialResultPrompts": [],
+            "label": "Granted",
+            "lastSharedDateTime": "2021-06-25",
+            "lifeDuration": false,
+            "orderedDate": "2021-06-25",
+            "orderedHearingId": "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2",
+            "publishedAsAPrompt": false,
+            "rank": 84300,
+            "resultText": "Granted\n",
+            "terminatesOffenceProceedings": false,
+            "urgent": false,
+            "usergroups": []
+          }
+        ],
+        "respondents": [
+          {
+            "id": "fee2b7db-c2d0-4723-9813-10833a855534",
+            "organisationPersons": [],
+            "prosecutingAuthority": {
+              "address": {
+                "address1": "Criminal Justice Department",
+                "address2": "Derbyshire Constabulary",
+                "address3": "Butterley Hall",
+                "postcode": "DE5 3RS"
+              },
+              "contact": {
+                "primaryEmail": "CCSU@derbyshire.pnn.police.uk"
+              },
+              "name": "Derbyshire Police",
+              "prosecutionAuthorityCode": "DERPF",
+              "prosecutionAuthorityId": "bdc190e7-c939-37ca-be4b-9f615d6ef40e"
+            }
+          }
+        ],
+        "subject": {
+          "id": "25d3a492-0bf0-4bb2-8aa7-2f084d70a9b2",
+          "masterDefendant": {
+            "defendantCase": [
+              {
+                "caseId": "598a9519-9a0f-4fd0-80de-a2c72a662739",
+                "caseReference": "90GD1000052",
+                "defendantId": "1c052ea0-03a4-4c37-bcce-bd4110508e77"
+              }
+            ],
+            "masterDefendantId": "1c052ea0-03a4-4c37-bcce-bd4110508e77",
+            "personDefendant": {
+              "arrestSummonsNumber": "TFL1",
+              "bailConditions": "",
+              "bailStatus": {
+                "code": "A",
+                "description": "Not applicable",
+                "id": "86009c70-759d-3308-8de4-194886ff9a77"
+              },
+              "personDetails": {
+                "address": {
+                  "address1": "1234",
+                  "address2": "StreetDescription",
+                  "address3": "Locality2O"
+                },
+                "dateOfBirth": "1990-01-01",
+                "documentationLanguageNeeds": "ENGLISH",
+                "firstName": "Darius",
+                "gender": "MALE",
+                "lastName": "ProhaskaOndricka",
+                "title": "Mr"
+              }
+            }
+          },
+          "organisationPersons": []
+        },
+        "thirdParties": [],
+        "type": {
+          "appealFlag": false,
+          "applicantAppellantFlag": false,
+          "breachType": "NOT_APPLICABLE",
+          "categoryCode": "CO",
+          "code": "BA76504",
+          "commrOfOathFlag": false,
+          "courtExtractAvlFlag": true,
+          "courtOfAppealFlag": false,
+          "id": "26c7e337-5697-3448-9b9b-f71a6a6e6b1f",
+          "jurisdiction": "EITHER",
+          "legislation": "In accordance with section 3(8) of the Bail Act 1976.",
+          "linkType": "LINKED",
+          "offenceActiveOrder": "OFFENCE",
+          "pleaApplicableFlag": false,
+          "prosecutorThirdPartyFlag": false,
+          "spiOutApplicableFlag": true,
+          "summonsTemplateType": "NOT_APPLICABLE",
+          "type": "Application to vary conditions of bail"
+        }
+      }
+    ],
+    "courtCentre": {
+      "address": {
+        "address1": "The Law Courts",
+        "address2": "Alexandra Road",
+        "address3": "Wimbledon",
+        "address4": "",
+        "address5": "",
+        "postcode": "SW19 7JP"
+      },
+      "code": "B01OK00",
+      "id": "d9bff7d8-6168-4163-ad77-3b98d61de174",
+      "name": "Wimbledon Magistrates' Court",
+      "roomId": "1414ea28-8b0e-3ba7-8f97-f2bb6d5dd38c",
+      "roomName": "Courtroom 05"
+    },
+    "defenceCounsels": [],
+    "defendantAttendance": [
+      {
+        "attendanceDays": [
+          {
+            "attendanceType": "IN_PERSON",
+            "day": "2021-06-25"
+          }
+        ],
+        "defendantId": "1c052ea0-03a4-4c37-bcce-bd4110508e77"
+      }
+    ],
+    "defendantHearingYouthMarkers": [],
+    "defendantJudicialResults": [],
+    "defendantReferralReasons": [],
+    "hasSharedResults": true,
+    "hearingCaseNotes": [],
+    "hearingDays": [
+      {
+        "listedDurationMinutes": 1,
+        "listingSequence": 0,
+        "sittingDay": "2021-06-25T09:00:00.000Z"
+      }
+    ],
+    "hearingLanguage": "ENGLISH",
+    "id": "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2",
+    "judiciary": [],
+    "jurisdictionType": "MAGISTRATES",
+    "prosecutionCases": [
+      {
+        "caseMarkers": [],
+        "caseStatus": "ACTIVE",
+        "defendants": [
+          {
+            "aliases": [],
+            "associatedDefenceOrganisation": {
+              "applicationReference": "LAA-20191601",
+              "associationEndDate": "2019-12-12",
+              "associationStartDate": "2019-09-12",
+              "fundingType": "REPRESENTATION_ORDER",
+              "isAssociatedByLAA": true,
+              "organisation": {
+                "address": {
+                  "address1": "a",
+                  "address2": "a",
+                  "address3": "a",
+                  "address4": "a",
+                  "address5": "a",
+                  "postcode": "GIR0AA"
+                },
+                "contact": {
+                  "fax": "a",
+                  "home": " ",
+                  "mobile": " ",
+                  "primaryEmail": "!.!@00.00",
+                  "secondaryEmail": "!.!@00.00",
+                  "work": "a"
+                },
+                "incorporationNumber": "a",
+                "name": "a",
+                "registeredCharityNumber": "a"
+              }
+            },
+            "associatedPersons": [],
+            "id": "1c052ea0-03a4-4c37-bcce-bd4110508e77",
+            "isYouth": false,
+            "judicialResults": [],
+            "masterDefendantId": "1c052ea0-03a4-4c37-bcce-bd4110508e77",
+            "offences": [
+              {
+                "arrestDate": "2020-02-09",
+                "chargeDate": "2020-02-09",
+                "count": 0,
+                "id": "f6259017-b2d1-400d-ae45-d9a610dfaeea",
+                "judicialResults": [],
+                "laaApplnReference": {
+                  "applicationReference": "LAA-20191601",
+                  "effectiveEndDate": "2019-12-12",
+                  "effectiveStartDate": "2019-09-12",
+                  "statusCode": "G2",
+                  "statusDate": "2019-12-16",
+                  "statusDescription": "Granted for Two Advocates",
+                  "statusId": "58ebf081-2b7d-3b1d-8c47-149fe7dbd672"
+                },
+                "modeOfTrial": "Summary",
+                "offenceCode": "CA03012",
+                "offenceDateCode": 1,
+                "offenceDefinitionId": "51ed3322-499a-4430-94cc-d52964f108db",
+                "offenceLegislation": "Contrary to section 363(3)(b) and (4) of the    Communications Act 2003.",
+                "offenceTitle": "Possess /    control TV set with intent another use install without a licence",
+                "orderIndex": 1,
+                "proceedingsConcluded": false,
+                "reportingRestrictions": [],
+                "startDate": "2020-02-09",
+                "victims": [],
+                "wording": "Has a violent past and fear that he will commit further offences and interfere with witnesse"
+              },
+              {
+                "arrestDate": "2020-02-09",
+                "chargeDate": "2020-02-09",
+                "count": 0,
+                "id": "f99e2c87-00d3-490a-98e1-f7d111147381",
+                "judicialResults": [],
+                "modeOfTrial": "Summary",
+                "offenceCode": "CA03013",
+                "offenceDateCode": 1,
+                "offenceDefinitionId": "062cedf4-b495-3a6c-9148-cec6bef362ef",
+                "offenceLegislation": "Contrary to section 366(8)(a) and (9) of the Communications Act 2003.",
+                "offenceTitle": "Obstruct person executing search warrant for TV receiver",
+                "orderIndex": 2,
+                "proceedingsConcluded": false,
+                "reportingRestrictions": [],
+                "startDate": "2020-02-09",
+                "victims": [],
+                "wording": "Has a violent past and fear that he will commit further offences and interfere with witnesse"
+              }
+            ],
+            "personDefendant": {
+              "arrestSummonsNumber": "TFL1",
+              "bailConditions": "",
+              "bailStatus": {
+                "code": "A",
+                "description": "Not applicable",
+                "id": "86009c70-759d-3308-8de4-194886ff9a77"
+              },
+              "personDetails": {
+                "address": {
+                  "address1": "1234",
+                  "address2": "StreetDescription",
+                  "address3": "Locality2O"
+                },
+                "dateOfBirth": "1990-01-01",
+                "documentationLanguageNeeds": "ENGLISH",
+                "firstName": "Darius",
+                "gender": "MALE",
+                "lastName": "ProhaskaOndricka",
+                "title": "Mr"
+              }
+            },
+            "proceedingsConcluded": false,
+            "prosecutionAuthorityReference": "TFL1",
+            "prosecutionCaseId": "598a9519-9a0f-4fd0-80de-a2c72a662739"
+          }
+        ],
+        "id": "598a9519-9a0f-4fd0-80de-a2c72a662739",
+        "initiationCode": "C",
+        "originatingOrganisation": "0300000",
+        "prosecutionCaseIdentifier": {
+          "prosecutionAuthorityCode": "DERPF",
+          "prosecutionAuthorityId": "bdc190e7-c939-37ca-be4b-9f615d6ef40e",
+          "prosecutionAuthorityName": "Derbyshire Police",
+          "caseURN": "90GD1000052"
+        }
+      }
+    ],
+    "prosecutionCounsels": [],
+    "respondentCounsels": [],
+    "type": {
+      "description": "Bail Variation Application",
+      "id": "3b5fdf13-7033-4ce0-857d-b7ea463da91d"
+    }
+  },
+  "sharedTime": "2021-06-25T09:38:02.191Z[UTC]"
+}


### PR DESCRIPTION
Changes the REST endpoint so that it receives a HearingEvent rather than a string. This was needed so that we can extract fields for the custom dimensions.

Added a couple of sample JSON files to support testing - the minimal one will probably have to get bigger.

