### PR TITLE
✨ PIC-1558 add S3 and upload incoming request bodies there

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
   validator-integration:
     docker:
       - image: circleci/openjdk:16-jdk-buster-browsers
-      - image: localstack/localstack:0.12.17
+      - image: localstack/localstack:0.11.2
         environment:
           - SERVICES=sqs,sns,s3
           - DEBUG=${DEBUG- }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ executors:
   validator-integration:
     docker:
       - image: circleci/openjdk:16-jdk-buster-browsers
-      - image: localstack/localstack:0.11.2
+      - image: localstack/localstack:0.12.17
         environment:
-          - SERVICES=sqs,sns
+          - SERVICES=sqs,sns,s3
           - DEBUG=${DEBUG- }
           - DATA_DIR=/tmp/localstack/data
           - DOCKER_HOST=unix:///var/run/docker.sock
@@ -76,6 +76,9 @@ jobs:
       - run:
           name: Wait for SQS to be ready
           command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566
+      - run:
+          name: Set up S3
+          command: bash src/test/resources/localstack/setup-sns.sh
       - run:
           name: Set up queues
           command: bash src/test/resources/localstack/setup-sns.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
   validator-integration:
     docker:
       - image: circleci/openjdk:16-jdk-buster-browsers
-      - image: localstack/localstack:0.11.2
+      - image: localstack/localstack:latest
         environment:
           - SERVICES=sqs,sns,s3
           - DEBUG=${DEBUG- }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.8"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.9"
   kotlin("plugin.spring") version "1.5.10"
 }
 
@@ -14,6 +14,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("com.amazonaws:aws-java-sdk-sns:1.11.1024")
   implementation("com.amazonaws:aws-java-sdk-sqs:1.11.1024")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.11.1024")
 
   implementation("io.springfox:springfox-swagger2:2.9.2")
   implementation("io.springfox:springfox-swagger-ui:2.9.2")

--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2021-10-01
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/adr/0002-store-incoming-payloads-to-s3.md
+++ b/doc/adr/0002-store-incoming-payloads-to-s3.md
@@ -1,0 +1,23 @@
+# 2. Store incoming payloads to S3
+
+Date: 2021-10-01
+
+## Status
+
+Accepted
+
+## Context
+
+We have a requirement to store the JSON messages that arrive in the request bodies to the EventController endpoints and this is done to an S3 bucket where they can be retained securely for 28 days. This could have been done by adding a service call in the EventController itself.   
+
+However, the EventController is a spring-managed endpoint and receives the payload already transformed into the required ```Hearing``` instance. If there was a problem parsing the payload, it would never arrive in the endpoint and the opportunity to store would have been lost. 
+
+Alternatively, a Filter could be implemented which intercepts the request before it arrives at the endpoint. This requires more code and a little more development effort.
+
+## Decision
+
+Decision taken to implement Filter so that no request body is lost.
+
+## Consequences
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - 8999:8080
       - 9080:9080
     environment:
-      - SERVICES=sns,sqs
+      - SERVICES=sns,sqs,s3
       - PORT_WEB_UI=9080
       - DEBUG=${DEBUG- }
       - DATA_DIR=/tmp/localstack/data

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/AwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/AwsConfig.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config
+
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Profile("!test")
+@Configuration
+class AwsConfig {
+
+  @Bean
+  fun amazonS3Client(
+    @Value("\${aws.region-name}") regionName: String,
+    @Value("\${aws.s3.access_key_id}") s3AccessKeyId: String,
+    @Value("\${aws.s3.secret_access_key}") s3SecretAccessKey: String
+  ): AmazonS3 {
+    val credentials: AWSCredentials = BasicAWSCredentials(s3AccessKeyId, s3SecretAccessKey)
+
+    return AmazonS3ClientBuilder
+      .standard()
+      .withCredentials(AWSStaticCredentialsProvider(credentials))
+      .withRegion(regionName)
+      .build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/CustomHttpRequestWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/CustomHttpRequestWrapper.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config.web
+
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.nio.charset.Charset
+import javax.servlet.ReadListener
+import javax.servlet.ServletInputStream
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletRequestWrapper
+
+class CustomHttpRequestWrapper(request: HttpServletRequest) : HttpServletRequestWrapper(request) {
+
+  var requestBody: String
+
+  init {
+    requestBody = readInputStreamInStringFormat(request.inputStream, Charset.forName(request.characterEncoding))
+  }
+
+  private fun readInputStreamInStringFormat(inputStream: InputStream, charset: Charset): String {
+    return String(inputStream.readAllBytes(), charset)
+  }
+
+  @Throws(IOException::class)
+  override fun getReader(): BufferedReader {
+    return BufferedReader(InputStreamReader(this.getInputStream()))
+  }
+
+  @Throws(IOException::class)
+  override fun getInputStream(): ServletInputStream {
+    val byteArrayInputStream = ByteArrayInputStream(requestBody.encodeToByteArray())
+    return object : ServletInputStream() {
+      private var finished = false
+      override fun isFinished(): Boolean {
+        return finished
+      }
+
+      @Throws(IOException::class)
+      override fun available(): Int {
+        return byteArrayInputStream.available()
+      }
+
+      @Throws(IOException::class)
+      override fun close() {
+        super.close()
+        byteArrayInputStream.close()
+      }
+
+      override fun isReady(): Boolean {
+        return true
+      }
+
+      override fun setReadListener(readListener: ReadListener) {
+        throw UnsupportedOperationException()
+      }
+
+      @Throws(IOException::class)
+      override fun read(): Int {
+        val data = byteArrayInputStream.read()
+        if (data == -1) {
+          finished = true
+        }
+        return data
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/S3LogFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/S3LogFilter.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config.web
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.S3Service
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+
+@Component
+class S3LogFilter(@Autowired private val s3Service: S3Service) : Filter {
+
+  override fun doFilter(request: ServletRequest, response: ServletResponse, filterChain: FilterChain) {
+
+    val httpRequest = request as HttpServletRequest
+    if (SUPPORTED_HTTP_METHODS.contains(HttpMethod.valueOf(httpRequest.method))) {
+      val requestWrapper = CustomHttpRequestWrapper(httpRequest)
+      filterChain.doFilter(requestWrapper, response)
+      s3Service.uploadMessage(request.requestURI, requestWrapper.requestBody)
+      return
+    }
+    filterChain.doFilter(request, response)
+  }
+
+  companion object {
+    @JvmField
+    var SUPPORTED_HTTP_METHODS = setOf(HttpMethod.DELETE, HttpMethod.POST, HttpMethod.PUT)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/extensions/global.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/extensions/global.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.extensions
+
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.MessageType
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+fun buildS3Key(courtCode: String, messageType: MessageType, receiptTime: LocalDateTime, hearingEventId: String): String {
+  return "cp" + PATH_DELIMITER + messageType + PATH_DELIMITER + courtCode + PATH_DELIMITER + receiptTime.toLocalDate().toString() + PATH_DELIMITER + receiptTime.toLocalTime().format(formatter) + FIELD_DELIMITER + hearingEventId
+}
+
+fun findUuid(string: String): String = UUID_REGEX.find(string).let { it?.value ?: "" }
+
+@JvmField
+var PATH_DELIMITER = "/"
+var FIELD_DELIMITER = "-"
+
+val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH-mm-ss")
+
+@JvmField
+var UUID_REGEX = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}".toRegex()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageType.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
+
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.extensions.UUID_REGEX
+import java.lang.IllegalArgumentException
+
+enum class MessageType(s: String) {
+  CONFIRM_UPDATE("confirm_update"), RESULT("result"), DELETE("delete"), UNKNOWN("unknown");
+}
+
+fun getMessageType(path: String): MessageType {
+
+  val elements = path.lowercase().split("/")
+  val finalElement = elements.last()
+
+  return when (UUID_REGEX.matches(finalElement)) {
+    true -> MessageType.CONFIRM_UPDATE
+    else -> {
+      try {
+        MessageType.valueOf(finalElement.uppercase())
+      } catch (iae: IllegalArgumentException) {
+        MessageType.UNKNOWN
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageType.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.extensions.UUID_REGEX
 import java.lang.IllegalArgumentException
 
-enum class MessageType(s: String) {
-  CONFIRM_UPDATE("confirm_update"), RESULT("result"), DELETE("delete"), UNKNOWN("unknown");
+enum class MessageType() {
+  CONFIRM_UPDATE(), RESULT(), DELETE(), UNKNOWN();
 }
 
 fun getMessageType(path: String): MessageType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/S3Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/S3Service.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
+
+import com.amazonaws.services.s3.AmazonS3
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.extensions.buildS3Key
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.extensions.findUuid
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.HearingEvent
+import java.lang.RuntimeException
+import java.time.LocalDateTime
+
+@Component
+class S3Service(
+  @Value("\${aws.s3.bucket_name}") private val bucketName: String,
+  @Autowired private val amazonS3Client: AmazonS3,
+  @Autowired private val mapper: ObjectMapper
+) {
+  fun uploadMessage(uriPath: String, messageContent: String): String? {
+
+    return try {
+      val s3Key = buildS3Key(
+        courtCode = getCourtCode(messageContent),
+        receiptTime = LocalDateTime.now(),
+        messageType = getMessageType(uriPath),
+        hearingEventId = findUuid(uriPath)
+      )
+
+      val putResult = amazonS3Client.putObject(bucketName, s3Key, messageContent)
+      log.info("File {} saved to S3 bucket {} with expiration date of {}, eTag {}", "TBD", bucketName, putResult.expirationTime, putResult.eTag)
+      putResult.eTag
+    } catch (ex: RuntimeException) {
+      // Happy to swallow this one with a log statement because failure to back up the file is not business critical
+      log.error("Failed to back up file {} saved to S3 bucket {}", "TBD", bucketName, ex)
+      null
+    }
+  }
+
+  fun getCourtCode(messageContent: String): String {
+    return try {
+      val hearingEvent = mapper.readValue<HearingEvent>(messageContent)
+      hearingEvent.hearing.courtCentre.code ?: "UNKNOWN_COURT"
+    } catch (ex: JsonProcessingException) {
+      log.error("Failed to parse ", ex)
+      "UNKNOWN_COURT"
+    }
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/CustomHttpRequestWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/CustomHttpRequestWrapperTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config.web
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import javax.servlet.ServletInputStream
+import javax.servlet.http.HttpServletRequest
+
+@ExtendWith(MockitoExtension::class)
+internal class CustomHttpRequestWrapperTest {
+
+  private lateinit var requestWrapper: CustomHttpRequestWrapper
+
+  @Mock
+  private lateinit var request: HttpServletRequest
+
+  @Mock
+  private lateinit var inputStream: ServletInputStream
+
+  @BeforeEach
+  fun beforeEach() {
+    whenever(request.inputStream).thenReturn(inputStream)
+    whenever(request.characterEncoding).thenReturn(CHARSET.name())
+
+    val byteArray = "Hello World".toByteArray(CHARSET)
+    whenever(inputStream.readAllBytes()).thenReturn(byteArray)
+    requestWrapper = CustomHttpRequestWrapper(request)
+  }
+
+  @Test
+  fun `when create then set requestBody`() {
+    val byteArray = "Hello World".toByteArray(CHARSET)
+    whenever(inputStream.readAllBytes()).thenReturn(byteArray)
+
+    val requestWrapper = CustomHttpRequestWrapper(request)
+
+    assertThat(requestWrapper.requestBody).isEqualTo("Hello World")
+  }
+
+  @Test
+  fun `when getInputStream then return`() {
+    val servletInputStream = requestWrapper.inputStream
+
+    assertThat(servletInputStream.isReady).isTrue
+    assertThat(servletInputStream.isFinished).isFalse
+    assertThat(servletInputStream.available()).isGreaterThan(10)
+    // H is 72
+    assertThat(servletInputStream.read()).isEqualTo(72)
+    while (servletInputStream.read() > 0) {
+      assertThat(servletInputStream.isFinished).isFalse
+    }
+    assertThat(servletInputStream.isFinished).isTrue
+    assertThat(servletInputStream.available()).isLessThanOrEqualTo(0)
+  }
+
+  @Test
+  fun `when getReader then return`() {
+    val bufferedReader = requestWrapper.getReader()
+
+    assertThat(bufferedReader.read()).isEqualTo(72)
+  }
+
+  companion object {
+    private val CHARSET = Charsets.UTF_8
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/S3LogFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/S3LogFilterTest.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config.web
+
+import com.nhaarman.mockitokotlin2.isA
+import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.S3Service
+import javax.servlet.FilterChain
+import javax.servlet.ServletInputStream
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@ExtendWith(MockitoExtension::class)
+internal class S3LogFilterTest {
+
+  private lateinit var s3LogFilter: S3LogFilter
+
+  @Mock
+  private lateinit var s3Service: S3Service
+
+  @Mock
+  private lateinit var request: HttpServletRequest
+
+  @Mock
+  private lateinit var response: HttpServletResponse
+
+  @Mock
+  private lateinit var inputStream: ServletInputStream
+
+  @Mock
+  private lateinit var chain: FilterChain
+
+  @BeforeEach
+  fun beforeEach() {
+    s3LogFilter = S3LogFilter(s3Service)
+  }
+
+  @Test
+  fun `when GET method then no logging`() {
+    whenever(request.method).thenReturn("GET")
+
+    s3LogFilter.doFilter(request, response, chain)
+
+    verify(chain).doFilter(request, response)
+    verifyNoMoreInteractions(chain, s3Service)
+  }
+
+  @Test
+  fun `when POST method then log body to S3`() {
+    whenever(request.method).thenReturn("POST")
+    whenever(request.inputStream).thenReturn(inputStream)
+    whenever(request.requestURI).thenReturn("/hearing/id/result")
+    whenever(request.characterEncoding).thenReturn(CHARSET.name())
+
+    val byteArray = "Hello World".toByteArray(CHARSET)
+    whenever(inputStream.readAllBytes()).thenReturn(byteArray)
+
+    s3LogFilter.doFilter(request, response, chain)
+
+    verify(chain).doFilter(isA<CustomHttpRequestWrapper>(), same(response))
+    verify(s3Service).uploadMessage("/hearing/id/result", "Hello World")
+    verifyNoMoreInteractions(chain, s3Service)
+  }
+
+  companion object {
+    private val CHARSET = Charsets.UTF_8
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
@@ -52,8 +52,6 @@ class EventControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun whenPostToEventEndpointWithRequiredRole_thenReturn200NoContent_andPushToTopic() {
-      val initialS3Count = s3Client.listObjects(bucketName).objectSummaries.size
-
       postEvent(
         hearingEvent,
         jwtHelper.createJwt("common-platform-events", roles = listOf("ROLE_COURT_HEARING_EVENT_WRITE"))
@@ -69,8 +67,6 @@ class EventControllerIntTest : IntegrationTestBase() {
 
       val expectedMap = mapOf("id" to "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2", "courtCode" to "B10JQ00")
       verify(telemetryService).trackEvent(TelemetryEventType.COURT_HEARING_UPDATE_EVENT_RECEIVED, expectedMap)
-
-      assertThat(s3Client.listObjects(bucketName).objectSummaries.size).isGreaterThan(initialS3Count)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/extensions/GlobalKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/extensions/GlobalKtTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.extensions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.MessageType
+import java.time.LocalDateTime
+import java.time.Month
+
+internal class GlobalKtTest {
+  @Test
+  fun `get path`() {
+
+    val courtCode = "B10JQ"
+    val messageType = MessageType.RESULT
+    val receiptTime = LocalDateTime.of(2021, Month.DECEMBER, 25, 23, 59, 59)
+
+    val path = buildS3Key(courtCode, messageType, receiptTime, UUID)
+
+    assertThat(path).isEqualTo("cp/" + messageType.name + "/" + courtCode + "/2021-12-25/23-59-59-" + UUID)
+  }
+
+  @Test
+  fun `get UUID`() {
+
+    val uuid = findUuid("/hearing/$UUID/delete")
+
+    assertThat(uuid).isEqualTo(UUID)
+  }
+
+  @Test
+  fun `get UUID when it is not present`() {
+
+    val uuid = findUuid("/hearing/delete")
+
+    assertThat(uuid).isEmpty()
+  }
+
+  @Test
+  fun `given multiple UUIDs when get UUID then return the first`() {
+
+    val uuid = findUuid("/hearing/$UUID/delete/8a400612-a942-41b9-ab04-8d090e20b095")
+
+    assertThat(uuid).isEqualTo(UUID)
+  }
+
+  companion object {
+    const val UUID = "c4bccab9-2261-427e-8c03-76c337b6593b"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.courthearingeventreceiver.integration
 
+import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.AmazonSNSClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSAsync
@@ -30,6 +33,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var jwtHelper: JwtAuthenticationHelper
+
+  @Value("\${aws.s3.bucket_name}")
+  lateinit var bucketName: String
 
   @TestConfiguration
   class AwsTestConfig(
@@ -65,6 +71,21 @@ abstract class IntegrationTestBase {
         .standard()
         .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(sqsEndpointUrl, regionName))
         .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(awsAccessKeyId, awsSecretAccessKey)))
+        .build()
+    }
+
+    @Bean
+    fun amazonS3Client(
+      @Value("\${aws.region-name}") regionName: String,
+      @Value("\${aws.s3.access_key_id}") s3AccessKeyId: String,
+      @Value("\${aws.s3.secret_access_key}") s3SecretAccessKey: String
+    ): AmazonS3 {
+      val credentials: AWSCredentials = BasicAWSCredentials(s3AccessKeyId, s3SecretAccessKey)
+
+      return AmazonS3ClientBuilder
+        .standard()
+        .withCredentials(AWSStaticCredentialsProvider(credentials))
+        .withRegion(regionName)
         .build()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
@@ -77,8 +77,8 @@ abstract class IntegrationTestBase {
     @Bean
     fun amazonS3Client(
       @Value("\${aws.region-name}") regionName: String,
-      @Value("\${aws.s3.access_key_id}") s3AccessKeyId: String,
-      @Value("\${aws.s3.secret_access_key}") s3SecretAccessKey: String
+      @Value("\${aws.sns.access_key_id}") s3AccessKeyId: String,
+      @Value("\${aws.sns.secret_access_key}") s3SecretAccessKey: String
     ): AmazonS3 {
       val credentials: AWSCredentials = BasicAWSCredentials(s3AccessKeyId, s3SecretAccessKey)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
@@ -77,8 +77,8 @@ abstract class IntegrationTestBase {
     @Bean
     fun amazonS3Client(
       @Value("\${aws.region-name}") regionName: String,
-      @Value("\${aws.sns.access_key_id}") s3AccessKeyId: String,
-      @Value("\${aws.sns.secret_access_key}") s3SecretAccessKey: String
+      @Value("\${aws.s3.access_key_id}") s3AccessKeyId: String,
+      @Value("\${aws.s3.secret_access_key}") s3SecretAccessKey: String
     ): AmazonS3 {
       val credentials: AWSCredentials = BasicAWSCredentials(s3AccessKeyId, s3SecretAccessKey)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageTypeTest.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class MessageTypeTest {
+
+  @Test
+  fun `when there is a result path return RESULT as type`() {
+
+    val messageType = getMessageType("/hearing/$UUID/result")
+
+    assertThat(messageType).isSameAs(MessageType.RESULT)
+  }
+
+  @Test
+  fun `when there is a result path return DELETE as type`() {
+
+    val messageType = getMessageType("/hearing/$UUID/delete")
+
+    assertThat(messageType).isSameAs(MessageType.DELETE)
+  }
+
+  @Test
+  fun `when there is a confirm update path return CONFIRM_UPDATE as type`() {
+
+    val messageType = getMessageType("/hearing/$UUID")
+
+    assertThat(messageType).isSameAs(MessageType.CONFIRM_UPDATE)
+  }
+
+  @Test
+  fun `when there is some other unknown path return UNKNOWN as type`() {
+
+    val messageType = getMessageType("/hearing/$UUID/operation/to/be/defined")
+
+    assertThat(messageType).isSameAs(MessageType.UNKNOWN)
+  }
+
+  companion object {
+    const val UUID = "c4bccab9-2261-427e-8c03-76c337b6593b"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/S3ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/S3ServiceTest.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.service
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.PutObjectResult
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argForWhich
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import java.io.File
+import java.util.Date
+
+@ExtendWith(MockitoExtension::class)
+internal class S3ServiceTest {
+
+  private lateinit var minimalJson: String
+
+  @Mock
+  lateinit var amazonS3Client: AmazonS3Client
+
+  private lateinit var s3Service: S3Service
+
+  @BeforeEach
+  fun setUp() {
+    val mapper = ObjectMapper()
+    mapper.registerModule(JavaTimeModule())
+    mapper.registerModule(KotlinModule())
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    s3Service = S3Service("bucket-name", amazonS3Client, mapper)
+    minimalJson = File("src/test/resources/json/court-application-minimal.json").readText(Charsets.UTF_8)
+  }
+
+  @Test
+  fun `given broken JSON input then message is uploaded as file`() {
+
+    val putResult: PutObjectResult = PutObjectResult().apply {
+      expirationTime = Date()
+      eTag = "ETAG"
+    }
+    whenever(amazonS3Client.putObject(eq("bucket-name"), argForWhich { startsWith("cp/RESULT/UNKNOWN_COURT/") }, eq("message")))
+      .thenReturn(putResult)
+
+    val eTag = s3Service.uploadMessage("/hearing/$UUID/result", "message")
+
+    verify(amazonS3Client).putObject(eq("bucket-name"), argForWhich { startsWith("cp/RESULT/UNKNOWN_COURT/") }, eq("message"))
+    verifyNoMoreInteractions(amazonS3Client)
+    assertThat(eTag).isEqualTo("ETAG")
+  }
+
+  @Test
+  fun `given normal JSON input then message is uploaded as file`() {
+
+    val putResult: PutObjectResult = PutObjectResult().apply {
+      expirationTime = Date()
+      eTag = "ETAG"
+    }
+    whenever(amazonS3Client.putObject(eq("bucket-name"), argForWhich { startsWith("cp/CONFIRM_UPDATE/B10JQ00/") }, any<String>()))
+      .thenReturn(putResult)
+
+    val eTag = s3Service.uploadMessage("/hearing/$UUID", minimalJson)
+
+    verify(amazonS3Client).putObject(eq("bucket-name"), argForWhich { startsWith("cp/CONFIRM_UPDATE/B10JQ00/") }, any<String>())
+    verifyNoMoreInteractions(amazonS3Client)
+    assertThat(eTag).isEqualTo("ETAG")
+  }
+
+  companion object {
+    const val UUID = "b9ebd552-8122-448d-8a11-e9c946a5cc0a"
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,3 +17,7 @@ aws:
     queue_name: "test-queue"
     access_key_id: foobar
     secret_access_key: foobar
+  s3:
+    access_key_id: foobar
+    secret_access_key: foobar
+    bucket_name: local-644707540a8083b7b15a77f51641f632

--- a/src/test/resources/localstack/setup-s3.sh
+++ b/src/test/resources/localstack/setup-s3.sh
@@ -7,6 +7,6 @@ export AWS_DEFAULT_REGION=eu-west-2
 export PAGER=
 
 # Create the bucket
-aws s3 --endpoint-url=http://localhost:4566 --region eu-west-2 ls s3://38c995c1-971b-4c3a-ba78-c9db73a796d0 || aws --endpoint-url=http://localhost:4566 --region=eu-west-2 s3 mb s3://38c995c1-971b-4c3a-ba78-c9db73a796d0
+aws s3 --endpoint-url=http://localhost:4566 --region eu-west-2 ls s3://local-644707540a8083b7b15a77f51641f632 || aws --endpoint-url=http://localhost:4566 --region=eu-west-2 s3 mb s3://local-644707540a8083b7b15a77f51641f632
 
 echo "S3 Configured with cpg-bucket"

--- a/src/test/resources/localstack/setup-s3.sh
+++ b/src/test/resources/localstack/setup-s3.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+export TERM=ansi
+export AWS_ACCESS_KEY_ID=foobar
+export AWS_SECRET_ACCESS_KEY=foobar
+export AWS_DEFAULT_REGION=eu-west-2
+export PAGER=
+
+# Create the bucket
+aws s3 --endpoint-url=http://localhost:4566 --region eu-west-2 ls s3://38c995c1-971b-4c3a-ba78-c9db73a796d0 || aws --endpoint-url=http://localhost:4566 --region=eu-west-2 s3 mb s3://38c995c1-971b-4c3a-ba78-c9db73a796d0
+
+echo "S3 Configured with cpg-bucket"


### PR DESCRIPTION
The request body can only be read from the `ServletInputStream` once so I followed this approach https://levelup.gitconnected.com/how-to-log-the-request-body-in-a-spring-boot-application-10083b70c66 to wrap and keep it for later process. 

As laid out in the ADR, did the logging from a filter which initially was driven by a desire not to lose payloads that failed to parse but in the end feels like a better separation. Fewer responsibilties in the endpoint.