### PR TITLE
✨ PIC-1620 validation of request bodies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,10 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-  implementation("com.amazonaws:aws-java-sdk-sns:1.11.1024")
-  implementation("com.amazonaws:aws-java-sdk-sqs:1.11.1024")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.11.1024")
+  implementation("org.springframework.boot:spring-boot-starter-validation")
+  implementation("com.amazonaws:aws-java-sdk-sns:1.12.81")
+  implementation("com.amazonaws:aws-java-sdk-sqs:1.12.81")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.81")
 
   implementation("io.springfox:springfox-swagger2:2.9.2")
   implementation("io.springfox:springfox-swagger-ui:2.9.2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/CourtHearingEventReceiverExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/CourtHearingEventReceiverExceptionHandler.kt
@@ -1,16 +1,22 @@
 package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config
 
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import javax.validation.ValidationException
 
 @RestControllerAdvice
-class CourtHearingEventReceiverExceptionHandler {
+class CourtHearingEventReceiverExceptionHandler : ResponseEntityExceptionHandler() {
+
   @ExceptionHandler(ValidationException::class)
   fun handleValidationException(e: Exception): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: {}", e.message)
@@ -39,8 +45,20 @@ class CourtHearingEventReceiverExceptionHandler {
       )
   }
 
+  public override fun handleMethodArgumentNotValid(ex: MethodArgumentNotValidException, headers: HttpHeaders, status: HttpStatus?, request: WebRequest?): ResponseEntity<Any?>? {
+    log.error("Unexpected exception", ex)
+    val response = ErrorResponse(status = 400, developerMessage = ex.message, userMessage = ex.message)
+    return ResponseEntity(response, BAD_REQUEST)
+  }
+
+  public override fun handleHttpMessageNotReadable(ex: HttpMessageNotReadableException, headers: HttpHeaders, status: HttpStatus?, request: WebRequest?): ResponseEntity<Any?>? {
+    log.error("Unexpected exception", ex)
+    val response = ErrorResponse(status = 400, developerMessage = ex.message, userMessage = ex.message)
+    return ResponseEntity(response, BAD_REQUEST)
+  }
+
   companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
+    private val log = LoggerFactory.getLogger(CourtHearingEventReceiverExceptionHandler::class.java)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventController.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.HearingEvent
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.MessageNotifier
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryEventType
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryService
+import javax.validation.Valid
 
 @Api(value = "Hearing Event")
 @RestController
@@ -30,7 +31,7 @@ class EventController(
   @ApiOperation(value = "Endpoint to receive hearing events of CONFIRMED/UPDATE type")
   @RequestMapping(value = ["/hearing/{id}"], method = [RequestMethod.POST], produces = [MediaType.APPLICATION_JSON_VALUE], consumes = [MediaType.APPLICATION_JSON_VALUE])
   @ResponseStatus(HttpStatus.OK)
-  fun postEvent(@PathVariable(required = false) id: String, @RequestBody hearingEvent: HearingEvent) {
+  fun postEvent(@PathVariable(required = false) id: String, @Valid @RequestBody hearingEvent: HearingEvent) {
     log.info("Received hearing event payload id: %s, path variable id: %s".format(hearingEvent.hearing.id, id))
     val hearing = hearingEvent.hearing
     telemetryService.trackEvent(
@@ -43,7 +44,7 @@ class EventController(
   @ApiOperation(value = "Endpoint to receive hearing events of RESULT type")
   @RequestMapping(value = ["/hearing/{id}/result"], method = [RequestMethod.POST], produces = [MediaType.APPLICATION_JSON_VALUE], consumes = [MediaType.APPLICATION_JSON_VALUE])
   @ResponseStatus(HttpStatus.OK)
-  fun postResultEvent(@PathVariable(required = false) id: String, @RequestBody hearingEvent: HearingEvent) {
+  fun postResultEvent(@PathVariable(required = false) id: String, @Valid @RequestBody hearingEvent: HearingEvent) {
     log.info("Received hearing event payload id: %s, path variable id: %s".format(hearingEvent.hearing.id, id))
     val hearing = hearingEvent.hearing
     telemetryService.trackEvent(
@@ -66,6 +67,6 @@ class EventController(
   }
 
   companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
+    private val log = LoggerFactory.getLogger(EventController::class.java)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Address.kt
@@ -6,7 +6,7 @@ import javax.validation.constraints.NotBlank
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Address(
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("address1")
   val address1: String,
   @JsonProperty("address2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/CourtCentre.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/CourtCentre.kt
@@ -2,18 +2,24 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import javax.validation.constraints.NotNull
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class CourtCentre(
-  @NotNull
+  @field:NotBlank
   @JsonProperty("id")
   val id: String,
 
+  @field:NotBlank
+  @field:Size(min = 5)
   @JsonProperty("code")
   val code: String?,
+
+  @field:NotBlank
   @JsonProperty("roomId")
-  val roomId: String?,
+  val roomId: String,
+
   @JsonProperty("roomName")
-  val roomName: String?
+  val roomName: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Defendant.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Defendant.kt
@@ -2,34 +2,38 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotEmpty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Defendant(
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("id")
   val id: String,
 
-  @NotEmpty
+  @field:Valid
+  @field:NotEmpty
   @JsonProperty("offences")
   val offences: List<Offence> = emptyList(),
 
   // This looks to be simply the same value as the id in the parent ProsecutionCase.
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("prosecutionCaseId")
   val prosecutionCaseId: String,
 
-  // We are told, but it is not confirmed in the schema, that there will be a personDefendant OR legalEntityDefendant
+  // There will be a personDefendant OR legalEntityDefendant
+  @field:Valid
   @JsonProperty("personDefendant")
   val personDefendant: PersonDefendant?,
 
+  @field:Valid
   @JsonProperty("legalEntityDefendant")
   val legalEntityDefendant: LegalEntityDefendant?,
 
   @JsonProperty("masterDefendantId")
-  val masterDefendantId: String,
+  val masterDefendantId: String?,
 
   @JsonProperty("pncId")
   val pncId: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Hearing.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Hearing.kt
@@ -27,7 +27,7 @@ data class Hearing(
 
   @field:NotNull
   @JsonProperty("jurisdictionType")
-  val jurisdictionType: JurisdictionType = JurisdictionType.MAGISTRATES,
+  val jurisdictionType: JurisdictionType,
 
   @field:Valid
   @field:NotEmpty

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Hearing.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Hearing.kt
@@ -4,30 +4,38 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.type.HearingType
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.type.JurisdictionType
+import javax.validation.Valid
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Hearing(
 
-  @NotNull
+  @field:NotBlank
   @JsonProperty("id")
   val id: String,
 
-  @NotNull
+  @field:NotNull
+  @field:Valid
   @JsonProperty("courtCentre")
   val courtCentre: CourtCentre,
 
-  @NotNull
+  @field:NotNull
   @JsonProperty("type")
   val type: HearingType,
 
-  @NotNull
+  @field:NotNull
   @JsonProperty("jurisdictionType")
   val jurisdictionType: JurisdictionType = JurisdictionType.MAGISTRATES,
 
+  @field:Valid
+  @field:NotEmpty
   @JsonProperty("hearingDays")
   val hearingDays: List<HearingDay> = emptyList(),
 
+  @field:Valid
+  @field:NotEmpty
   @JsonProperty("prosecutionCases")
   val prosecutionCases: List<ProsecutionCase> = emptyList()
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingDay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingDay.kt
@@ -4,19 +4,20 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 import javax.validation.constraints.NotNull
-import javax.validation.constraints.Positive
+import javax.validation.constraints.PositiveOrZero
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class HearingDay(
 
-  @NotNull
+  @field:NotNull
   @JsonProperty("sittingDay")
   val sittingDay: LocalDateTime,
 
-  @Positive
+  @field:PositiveOrZero
   @JsonProperty("listedDurationMinutes")
   val listedDurationMinutes: Int,
 
+  @field:PositiveOrZero
   @JsonProperty("listingSequence")
-  val listingSequence: Int?
+  val listingSequence: Int
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/HearingEvent.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.jetbrains.annotations.NotNull
+import javax.validation.Valid
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class HearingEvent(
+  @field:Valid
+  @field:NotNull
+  @JsonProperty("hearing")
   var hearing: Hearing
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/LegalEntityDefendant.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/LegalEntityDefendant.kt
@@ -2,11 +2,13 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class LegalEntityDefendant(
-  @NotNull
+  @field:Valid
+  @field:NotNull
   @JsonProperty("organisation")
   val organisation: Organisation
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Offence.kt
@@ -5,23 +5,23 @@ import javax.validation.constraints.NotBlank
 
 data class Offence(
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("id")
   val id: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("offenceDefinitionId")
   val offenceDefinitionId: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("offenceCode")
   val offenceCode: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("offenceTitle")
   val offenceTitle: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("wording")
   val wording: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Organisation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/Organisation.kt
@@ -6,10 +6,10 @@ import javax.validation.constraints.NotBlank
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Organisation(
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("name")
   val name: String,
 
   @JsonProperty("address")
-  val address: Address
+  val address: Address?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/PersonDefendant.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/PersonDefendant.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PersonDefendant(
 
-  @NotNull
+  @field:NotNull
+  @field:Valid
   @JsonProperty("personDetails")
   val personDetails: PersonDetails
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/PersonDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/PersonDetails.kt
@@ -4,27 +4,32 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.type.Gender
 import java.time.LocalDate
+import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PersonDetails(
 
-  @NotNull
+  @field:NotNull
   @JsonProperty("gender")
   val gender: Gender,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("lastName")
   val lastName: String,
 
+  @JsonProperty("middleName")
+  val middleName: String?,
+
   @JsonProperty("firstName")
-  val firstName: String,
+  val firstName: String?,
 
   @JsonProperty("dateOfBirth")
-  val dateOfBirth: LocalDate,
+  val dateOfBirth: LocalDate?,
 
+  @field:Valid
   @JsonProperty("address")
-  val address: Address
+  val address: Address?
 
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/ProsecutionCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/ProsecutionCase.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.type.InitiationCode
+import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
@@ -10,19 +11,20 @@ import javax.validation.constraints.NotNull
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ProsecutionCase(
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("id")
   val id: String,
 
-  @NotNull
+  @field:NotNull
   @JsonProperty("initiationCode")
   val initiationCode: InitiationCode,
 
-  @NotNull
+  @field:NotNull
   @JsonProperty("prosecutionCaseIdentifier")
   val prosecutionCaseIdentifier: ProsecutionCaseIdentifier,
 
-  @NotEmpty
+  @field:Valid
+  @field:NotEmpty
   @JsonProperty("defendants")
   val defendants: List<Defendant> = emptyList(),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/ProsecutionCaseIdentifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/ProsecutionCaseIdentifier.kt
@@ -6,15 +6,15 @@ import javax.validation.constraints.NotBlank
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ProsecutionCaseIdentifier(
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("prosecutionAuthorityCode")
   val prosecutionAuthorityCode: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("prosecutionAuthorityId")
   val prosecutionAuthorityId: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("caseURN")
   val caseURN: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/S3Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/S3Service.kt
@@ -22,20 +22,20 @@ class S3Service(
 ) {
   fun uploadMessage(uriPath: String, messageContent: String): String? {
 
-    return try {
-      val s3Key = buildS3Key(
-        courtCode = getCourtCode(messageContent),
-        receiptTime = LocalDateTime.now(),
-        messageType = getMessageType(uriPath),
-        hearingEventId = findUuid(uriPath)
-      )
+    val s3Key = buildS3Key(
+      courtCode = getCourtCode(messageContent),
+      receiptTime = LocalDateTime.now(),
+      messageType = getMessageType(uriPath),
+      hearingEventId = findUuid(uriPath)
+    )
 
+    return try {
       val putResult = amazonS3Client.putObject(bucketName, s3Key, messageContent)
       log.info("File {} saved to S3 bucket {} with expiration date of {}, eTag {}", "TBD", bucketName, putResult.expirationTime, putResult.eTag)
       putResult.eTag
     } catch (ex: RuntimeException) {
       // Happy to swallow this one with a log statement because failure to back up the file is not business critical
-      log.error("Failed to back up file {} saved to S3 bucket {}", "TBD", bucketName, ex)
+      log.error("Failed to back up file {} saved to S3 bucket {}", s3Key, bucketName, ex)
       null
     }
   }
@@ -51,6 +51,6 @@ class S3Service(
   }
 
   companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
+    private val log = LoggerFactory.getLogger(S3Service::class.java)
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,17 @@
 hmpps-auth:
   baseurl: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
+logging:
+  level:
+    root: WARN
+    uk:
+      gov:
+        justice:
+          digital:
+            hmpps: TRACE
+
+#
+
 # Localstack settings
 aws:
   region_name: eu-west-2
@@ -13,3 +24,7 @@ aws:
     queue_name: "test-queue"
     access_key_id: foobar
     secret_access_key: foobar
+  s3:
+    access_key_id: foobar
+    secret_access_key: foobar
+    bucket_name: local-644707540a8083b7b15a77f51641f632

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,17 +1,6 @@
 hmpps-auth:
   baseurl: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
-logging:
-  level:
-    root: WARN
-    uk:
-      gov:
-        justice:
-          digital:
-            hmpps: TRACE
-
-#
-
 # Localstack settings
 aws:
   region_name: eu-west-2

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/CourtHearingEventReceiverExceptionHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/CourtHearingEventReceiverExceptionHandlerTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+
+@ExtendWith(MockitoExtension::class)
+internal class CourtHearingEventReceiverExceptionHandlerTest {
+
+  private lateinit var exceptionHandler: CourtHearingEventReceiverExceptionHandler
+
+  private val headers = HttpHeaders()
+
+  @Mock
+  lateinit var methodArgumentNotValidException: MethodArgumentNotValidException
+
+  @Mock
+  lateinit var messageNotReadableException: HttpMessageNotReadableException
+
+  @BeforeEach
+  fun beforeEach() {
+    exceptionHandler = CourtHearingEventReceiverExceptionHandler()
+  }
+
+  @Test
+  fun `given invalid method argument when get message then return BAD_REQUEST`() {
+    whenever(methodArgumentNotValidException.message).thenReturn("MESSAGE")
+
+    val response = exceptionHandler.handleMethodArgumentNotValid(methodArgumentNotValidException, headers, HttpStatus.INTERNAL_SERVER_ERROR, null)
+
+    assertThat(response?.body.toString()).contains("MESSAGE")
+    assertThat(response?.statusCode?.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
+  }
+
+  @Test
+  fun `given message not readable when get message then return BAD_REQUEST`() {
+
+    whenever(messageNotReadableException.message).thenReturn("MESSAGE")
+
+    val response = exceptionHandler.handleHttpMessageNotReadable(messageNotReadableException, headers, HttpStatus.INTERNAL_SERVER_ERROR, null)
+
+    assertThat(response?.body.toString()).contains("MESSAGE")
+    assertThat(response?.statusCode?.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/ModelParserTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/model/ModelParserTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.model
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -26,6 +27,7 @@ internal class ModelParserTest {
   fun beforeEach() {
     mapper = ObjectMapper()
     mapper.registerModule(JavaTimeModule())
+    mapper.registerModule(KotlinModule())
     mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
   }
 
@@ -37,7 +39,7 @@ internal class ModelParserTest {
     val hearing = mapper.readValue(content, Hearing::class.java)
 
     assertThat(hearing.id).isEqualTo("8bbb4fe3-a899-45c7-bdd4-4ee25ac5a83f")
-    assertThat(hearing.courtCentre.code).isNull()
+    assertThat(hearing.courtCentre.code).isEqualTo("B05KP00")
     assertThat(hearing.type.description).isEqualTo("Sentence")
     assertThat(hearing.jurisdictionType).isSameAs(JurisdictionType.CROWN)
     assertThat(hearing.hearingDays.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageNotifierTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageNotifierTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.CourtCentre
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.Hearing
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.HearingEvent
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.type.HearingType
+import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.type.JurisdictionType
 
 @ExtendWith(SpringExtension::class, MockitoExtension::class)
 @Import(MessageNotifierTest.TestNotifierConfig::class)
@@ -45,7 +46,8 @@ internal class MessageNotifierTest {
       hearing = Hearing(
         id = "hearing-id",
         courtCentre = CourtCentre(code = "B10JQ", roomId = "abc", roomName = "Crown Court 3-1", id = "abc"),
-        type = HearingType(id = "abc", description = "Sentence")
+        type = HearingType(id = "abc", description = "Sentence"),
+        jurisdictionType = JurisdictionType.MAGISTRATES
       )
     )
     val result = PublishResult().withMessageId("messageId")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,9 +5,6 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
-hmppsauth:
-  baseurl: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-
 # Localstack settings
 aws:
   region_name: eu-west-2

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,6 +5,9 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
+hmppsauth:
+  baseurl: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+
 # Localstack settings
 aws:
   region_name: eu-west-2

--- a/src/test/resources/json/court-application-invalid.json
+++ b/src/test/resources/json/court-application-invalid.json
@@ -1,0 +1,30 @@
+{
+  "hearing": {
+    "courtCentre": {
+      "address": {
+        "address1": "The Law Courts",
+        "address2": "Alexandra Road",
+        "address3": "Wimbledon",
+        "address4": "",
+        "address5": "",
+        "postcode": "SW19 7JP"
+      },
+      "name": "Wimbledon Magistrates' Court",
+      "roomId": "1414ea28-8b0e-3ba7-8f97-f2bb6d5dd38c",
+      "roomName": "Courtroom 05",
+      "id": "59cb14a6-e8de-4615-9b9e-94bf5ef81ad2"
+    },
+    "hearingDays": [
+      {
+        "listedDurationMinutes": 1,
+        "listingSequence": 0,
+        "sittingDay": "2021-06-25T09:00:00.000Z"
+      }
+    ],
+    "jurisdictionType": "MAGISTRATES",
+    "type": {
+      "description": "Sentence",
+      "id": "5ae4c090-0f70-4694-b4fc-707633d2b430"
+    }
+  }
+}

--- a/src/test/resources/json/court-application-minimal.json
+++ b/src/test/resources/json/court-application-minimal.json
@@ -24,6 +24,65 @@
     ],
     "id": "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2",
     "jurisdictionType": "MAGISTRATES",
+    "prosecutionCases":
+    [
+      {
+        "caseStatus": "ACTIVE",
+        "defendants":
+        [
+          {
+            "id": "ac24a1be-939b-49a4-a524-21a3d228f8bc",
+            "masterDefendantId": "ac24a1be-939b-49a4-a524-21a3d228f8bc",
+            "offences":
+            [
+              {
+                "id": "3e1218c4-1946-429b-9cb6-f497206405a6",
+                "modeOfTrial": "Summary",
+                "offenceCode": "CA03013",
+                "offenceDefinitionId": "062cedf4-b495-3a6c-9148-cec6bef362ed",
+                "offenceLegislation": "Contrary to section 366(8)(a) and    (9) of the Communications Act 2003.",
+                "offenceTitle": "Obstruct person executing search warrant for TV receiver",
+                "orderIndex": 1,
+                "wording": "Has a violent past and fear that he will commit further offences and\n                interfere with witnesse"
+              }
+            ],
+            "personDefendant":
+            {
+              "personDetails":
+              {
+                "address":
+                {
+                  "address1": "1234",
+                  "address2": "StreetDescription",
+                  "address3": "Locality2O"
+                },
+                "dateOfBirth": "1982-06-29",
+                "documentationLanguageNeeds": "ENGLISH",
+                "firstName": "Geoff",
+                "gender": "MALE",
+                "hearingLanguageNeeds": "ENGLISH",
+                "lastName": "Klingon",
+                "title": "Mr"
+              }
+            },
+            "prosecutionAuthorityReference": "TFL",
+            "prosecutionCaseId": "1d1861ed-e18c-429d-bad0-671802f9cdba"
+          }
+        ],
+        "id": "1d1861ed-e18c-429d-bad0-671802f9cdba",
+        "initiationCode": "C",
+        "originatingOrganisation": "0300000",
+        "prosecutionCaseIdentifier":
+        {
+          "majorCreditorCode": "PF30",
+          "prosecutionAuthorityCode": "DERPF",
+          "prosecutionAuthorityId": "bdc190e7-c939-37ca-be4b-9f615d6ef40e",
+          "prosecutionAuthorityName": "Derbyshire Police",
+          "prosecutionAuthorityOUCode": "0300000",
+          "caseURN": "80GD8183221"
+        }
+      }
+    ],
     "type": {
       "description": "Sentence",
       "id": "5ae4c090-0f70-4694-b4fc-707633d2b430"

--- a/src/test/resources/json/hearing-1.json
+++ b/src/test/resources/json/hearing-1.json
@@ -1,205 +1,220 @@
 {
-  "courtCentre": {
-    "id": "9b583616-049b-30f9-a14f-028a53b7cfe8",
-    "name": "Liverpool Crown Court",
-    "roomId": "7cb09222-49e1-3622-a5a6-ad253d2b3c39",
-    "roomName": "Crown Court 3-1"
-  },
-  "hearingDays": [{
-    "listedDurationMinutes": 30,
-    "listingSequence": 0,
-    "sittingDay": "2019-01-28T10:30:00.000Z"
-  }],
-  "hearingLanguage": "ENGLISH",
-  "id": "8bbb4fe3-a899-45c7-bdd4-4ee25ac5a83f",
-  "jurisdictionType": "CROWN",
-  "prosecutionCases": [{
-    "caseStatus": "READY_FOR_REVIEW",
-    "defendants": [{
-      "courtProceedingsInitiated": "2019-02-28T15:19:22.202Z",
-      "defenceOrganisation": {
-        "name": "Teste"
-      },
-      "id": "0ab7c3e5-eb4c-4e3f-b9e6-b9e78d3ea199",
-      "masterDefendantId": "0ab7c3e5-eb4c-4e3f-b9e6-b9e78d3ea199",
-      "offences": [{
-        "allocationDecision": {
-          "allocationDecisionDate": "2019-01-01",
-          "motReasonCode": "7",
-          "motReasonDescription": "No mode of Trial - Either way offence",
-          "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "sequenceNumber": 70
-        },
-        "convictionDate": "2019-01-01",
-        "count": 1,
-        "endDate": "2011-08-01",
-        "id": "a63d9020-aa6b-4997-92fd-72a692b036de",
-        "modeOfTrial": "Either Way",
-        "offenceCode": "OF61131",
-        "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
-        "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-        "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
-        "offenceTitle": "Wound / inflict grievous bodily harm without intent",
-        "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
-        "plea": {
-          "offenceId": "a63d9020-aa6b-4997-92fd-72a692b036de",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "pleaDate": "2019-01-01",
-          "pleaValue": "GUILTY"
-        },
-        "startDate": "2010-08-01",
-        "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
-      }, {
-        "allocationDecision": {
-          "allocationDecisionDate": "2019-01-01",
-          "motReasonCode": "7",
-          "motReasonDescription": "No mode of Trial - Either way offence",
-          "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "sequenceNumber": 70
-        },
-        "convictionDate": "2019-01-01",
-        "count": 2,
-        "endDate": "2011-08-01",
-        "id": "ea1c2cf1-f155-483b-a908-81158a9b2f9b",
-        "modeOfTrial": "Either Way",
-        "offenceCode": "OF61131",
-        "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
-        "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-        "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
-        "offenceTitle": "Wound / inflict grievous bodily harm without intent",
-        "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
-        "plea": {
-          "offenceId": "ea1c2cf1-f155-483b-a908-81158a9b2f9b",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "pleaDate": "2019-01-01",
-          "pleaValue": "GUILTY"
-        },
-        "startDate": "2010-08-01",
-        "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
-      }],
-      "personDefendant": {
-        "bailStatus": {
-          "code": "U",
-          "description": "Unconditional Bail",
-          "id": "eaf18bf8-9569-3656-a4ab-64299f9bd513"
-        },
-        "personDetails": {
-          "address": {
-            "address1": "14 Tottenham Court Road",
-            "address2": "London Road",
-            "address3": "England",
-            "address4": "UK"
+    "courtCentre": {
+      "id": "9b583616-049b-30f9-a14f-028a53b7cfe8",
+      "name": "Liverpool Crown Court",
+      "roomId": "7cb09222-49e1-3622-a5a6-ad253d2b3c39",
+      "roomName": "Crown Court 3-1",
+      "code":"B05KP00"
+    },
+    "hearingDays": [
+      {
+        "listedDurationMinutes": 30,
+        "listingSequence": 0,
+        "sittingDay": "2019-01-28T10:30:00.000Z"
+      }
+    ],
+    "hearingLanguage": "ENGLISH",
+    "id": "8bbb4fe3-a899-45c7-bdd4-4ee25ac5a83f",
+    "jurisdictionType": "CROWN",
+    "prosecutionCases": [
+      {
+        "caseStatus": "READY_FOR_REVIEW",
+        "defendants": [
+          {
+            "courtProceedingsInitiated": "2019-02-28T15:19:22.202Z",
+            "defenceOrganisation": {
+              "name": "Teste"
+            },
+            "id": "0ab7c3e5-eb4c-4e3f-b9e6-b9e78d3ea199",
+            "masterDefendantId": "0ab7c3e5-eb4c-4e3f-b9e6-b9e78d3ea199",
+            "offences": [
+              {
+                "allocationDecision": {
+                  "allocationDecisionDate": "2019-01-01",
+                  "motReasonCode": "7",
+                  "motReasonDescription": "No mode of Trial - Either way offence",
+                  "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "sequenceNumber": 70
+                },
+                "convictionDate": "2019-01-01",
+                "count": 1,
+                "endDate": "2011-08-01",
+                "id": "a63d9020-aa6b-4997-92fd-72a692b036de",
+                "modeOfTrial": "Either Way",
+                "offenceCode": "OF61131",
+                "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
+                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
+                "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
+                "offenceTitle": "Wound / inflict grievous bodily harm without intent",
+                "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
+                "plea": {
+                  "offenceId": "a63d9020-aa6b-4997-92fd-72a692b036de",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "pleaDate": "2019-01-01",
+                  "pleaValue": "GUILTY"
+                },
+                "startDate": "2010-08-01",
+                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
+              },
+              {
+                "allocationDecision": {
+                  "allocationDecisionDate": "2019-01-01",
+                  "motReasonCode": "7",
+                  "motReasonDescription": "No mode of Trial - Either way offence",
+                  "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "sequenceNumber": 70
+                },
+                "convictionDate": "2019-01-01",
+                "count": 2,
+                "endDate": "2011-08-01",
+                "id": "ea1c2cf1-f155-483b-a908-81158a9b2f9b",
+                "modeOfTrial": "Either Way",
+                "offenceCode": "OF61131",
+                "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
+                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
+                "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
+                "offenceTitle": "Wound / inflict grievous bodily harm without intent",
+                "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
+                "plea": {
+                  "offenceId": "ea1c2cf1-f155-483b-a908-81158a9b2f9b",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "pleaDate": "2019-01-01",
+                  "pleaValue": "GUILTY"
+                },
+                "startDate": "2010-08-01",
+                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
+              }
+            ],
+            "personDefendant": {
+              "bailStatus": {
+                "code": "U",
+                "description": "Unconditional Bail",
+                "id": "eaf18bf8-9569-3656-a4ab-64299f9bd513"
+              },
+              "personDetails": {
+                "address": {
+                  "address1": "14 Tottenham Court Road",
+                  "address2": "London Road",
+                  "address3": "England",
+                  "address4": "UK"
+                },
+                "dateOfBirth": "1983-02-28",
+                "firstName": "Trevion",
+                "gender": "MALE",
+                "lastName": "McCullough",
+                "nationalityCode": "GBR",
+                "nationalityDescription": "British",
+                "nationalityId": "49433158-3542-49c8-a9af-581a0e746152"
+              }
+            },
+            "prosecutionCaseId": "b7417f11-49d8-482d-b516-ba4135d38d0d"
           },
-          "dateOfBirth": "1983-02-28",
-          "firstName": "Trevion",
-          "gender": "MALE",
-          "lastName": "McCullough",
-          "nationalityCode": "GBR",
-          "nationalityDescription": "British",
-          "nationalityId": "49433158-3542-49c8-a9af-581a0e746152"
+          {
+            "courtProceedingsInitiated": "2019-02-28T15:19:22.202Z",
+            "defenceOrganisation": {
+              "name": "test"
+            },
+            "id": "903c4c54-f667-4770-8fdf-1adbb5957c25",
+            "masterDefendantId": "903c4c54-f667-4770-8fdf-1adbb5957c25",
+            "offences": [
+              {
+                "allocationDecision": {
+                  "allocationDecisionDate": "2019-01-01",
+                  "motReasonCode": "7",
+                  "motReasonDescription": "No mode of Trial - Either way offence",
+                  "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "sequenceNumber": 70
+                },
+                "convictionDate": "2019-01-01",
+                "count": 0,
+                "endDate": "2011-08-01",
+                "id": "f861a3dc-6b7a-4ddd-88c8-0f141ae154be",
+                "modeOfTrial": "Either Way",
+                "offenceCode": "OF61131",
+                "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
+                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
+                "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
+                "offenceTitle": "Wound / inflict grievous bodily harm without intent",
+                "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
+                "plea": {
+                  "offenceId": "f861a3dc-6b7a-4ddd-88c8-0f141ae154be",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "pleaDate": "2019-01-01",
+                  "pleaValue": "GUILTY"
+                },
+                "startDate": "2010-08-01",
+                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
+              },
+              {
+                "allocationDecision": {
+                  "allocationDecisionDate": "2019-01-01",
+                  "motReasonCode": "7",
+                  "motReasonDescription": "No mode of Trial - Either way offence",
+                  "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "sequenceNumber": 70
+                },
+                "convictionDate": "2019-01-01",
+                "count": 0,
+                "endDate": "2011-08-01",
+                "id": "18db7545-5783-4410-aba6-f59bf3ae1f30",
+                "modeOfTrial": "Either Way",
+                "offenceCode": "OF61131",
+                "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
+                "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
+                "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
+                "offenceTitle": "Wound / inflict grievous bodily harm without intent",
+                "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
+                "plea": {
+                  "offenceId": "18db7545-5783-4410-aba6-f59bf3ae1f30",
+                  "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
+                  "pleaDate": "2019-01-01",
+                  "pleaValue": "GUILTY"
+                },
+                "startDate": "2010-08-01",
+                "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
+              }
+            ],
+            "personDefendant": {
+              "bailStatus": {
+                "code": "U",
+                "description": "Unconditional Bail",
+                "id": "eaf18bf8-9569-3656-a4ab-64299f9bd513"
+              },
+              "personDetails": {
+                "address": {
+                  "address1": "14 Tottenham Court Road",
+                  "address2": "London Road",
+                  "address3": "England",
+                  "address4": "UK"
+                },
+                "dateOfBirth": "1997-02-28",
+                "firstName": "Trycia",
+                "gender": "MALE",
+                "lastName": "Leffler",
+                "nationalityCode": "GBR",
+                "nationalityDescription": "British",
+                "nationalityId": "49433158-3542-49c8-a9af-581a0e746152"
+              }
+            },
+            "prosecutionCaseId": "b7417f11-49d8-482d-b516-ba4135d38d0d"
+          }
+        ],
+        "id": "b7417f11-49d8-482d-b516-ba4135d38d0d",
+        "initiationCode": "C",
+        "prosecutionCaseIdentifier": {
+          "prosecutionAuthorityCode": "CPS",
+          "prosecutionAuthorityId": "52b27284-0686-4894-b1c7-7d4b634cacdb",
+          "caseURN": "74GD8837719"
         }
-      },
-      "prosecutionCaseId": "b7417f11-49d8-482d-b516-ba4135d38d0d"
-    }, {
-      "courtProceedingsInitiated": "2019-02-28T15:19:22.202Z",
-      "defenceOrganisation": {
-        "name": "test"
-      },
-      "id": "903c4c54-f667-4770-8fdf-1adbb5957c25",
-      "masterDefendantId": "903c4c54-f667-4770-8fdf-1adbb5957c25",
-      "offences": [{
-        "allocationDecision": {
-          "allocationDecisionDate": "2019-01-01",
-          "motReasonCode": "7",
-          "motReasonDescription": "No mode of Trial - Either way offence",
-          "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "sequenceNumber": 70
-        },
-        "convictionDate": "2019-01-01",
-        "count": 0,
-        "endDate": "2011-08-01",
-        "id": "f861a3dc-6b7a-4ddd-88c8-0f141ae154be",
-        "modeOfTrial": "Either Way",
-        "offenceCode": "OF61131",
-        "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
-        "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-        "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
-        "offenceTitle": "Wound / inflict grievous bodily harm without intent",
-        "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
-        "plea": {
-          "offenceId": "f861a3dc-6b7a-4ddd-88c8-0f141ae154be",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "pleaDate": "2019-01-01",
-          "pleaValue": "GUILTY"
-        },
-        "startDate": "2010-08-01",
-        "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
-      }, {
-        "allocationDecision": {
-          "allocationDecisionDate": "2019-01-01",
-          "motReasonCode": "7",
-          "motReasonDescription": "No mode of Trial - Either way offence",
-          "motReasonId": "78efce20-8a52-3272-9d22-2e7e6e3e565e",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "sequenceNumber": 70
-        },
-        "convictionDate": "2019-01-01",
-        "count": 0,
-        "endDate": "2011-08-01",
-        "id": "18db7545-5783-4410-aba6-f59bf3ae1f30",
-        "modeOfTrial": "Either Way",
-        "offenceCode": "OF61131",
-        "offenceDefinitionId": "6abe3e81-1de0-4c42-b0d2-2dc38f5c44c5",
-        "offenceLegislation": "Contrary to section 20 of the Offences Against the    Person Act 1861.",
-        "offenceLegislationWelsh": "Yn groes i adran 20 Deddf Troseddau Corfforol 1861.",
-        "offenceTitle": "Wound / inflict grievous bodily harm without intent",
-        "offenceTitleWelsh": "Clwyfo / peri niwed corfforol difrifol heb fwriadu",
-        "plea": {
-          "offenceId": "18db7545-5783-4410-aba6-f59bf3ae1f30",
-          "originatingHearingId": "c1d3a081-85f1-40a1-bd31-ec5e6677249e",
-          "pleaDate": "2019-01-01",
-          "pleaValue": "GUILTY"
-        },
-        "startDate": "2010-08-01",
-        "wording": "on 01/08/2009 at  the County public house, unlawfully and maliciously wounded, John Smith"
-      }],
-      "personDefendant": {
-        "bailStatus": {
-          "code": "U",
-          "description": "Unconditional Bail",
-          "id": "eaf18bf8-9569-3656-a4ab-64299f9bd513"
-        },
-        "personDetails": {
-          "address": {
-            "address1": "14 Tottenham Court Road",
-            "address2": "London Road",
-            "address3": "England",
-            "address4": "UK"
-          },
-          "dateOfBirth": "1997-02-28",
-          "firstName": "Trycia",
-          "gender": "MALE",
-          "lastName": "Leffler",
-          "nationalityCode": "GBR",
-          "nationalityDescription": "British",
-          "nationalityId": "49433158-3542-49c8-a9af-581a0e746152"
-        }
-      },
-      "prosecutionCaseId": "b7417f11-49d8-482d-b516-ba4135d38d0d"
-    }],
-    "id": "b7417f11-49d8-482d-b516-ba4135d38d0d",
-    "initiationCode": "C",
-    "prosecutionCaseIdentifier": {
-      "prosecutionAuthorityCode": "CPS",
-      "prosecutionAuthorityId": "52b27284-0686-4894-b1c7-7d4b634cacdb",
-      "caseURN": "74GD8837719"
+      }
+    ],
+    "type": {
+      "description": "Sentence",
+      "id": "5ae4c090-0f70-4694-b4fc-707633d2b430"
     }
-  }],
-  "type": {
-    "description": "Sentence",
-    "id": "5ae4c090-0f70-4694-b4fc-707633d2b430"
-  }
+
 }


### PR DESCRIPTION
A couple of extra comments 
- I had to override `ResponseEntityExceptionHandler`  in `CourtHearingEventReceiverExceptionHandler` to get the response body populated with something useful. The main one was `MethodArgumentNotValidException` but I also did a test where I removed the top level id from the `Hearing` and for some reason, that threw a `HttpMessageNotReadableException`
- Learnt in Kotlin that you have to have @field:NotBlank and not just @NotBlank  for validation to work, although I think this is because of the fact that they are in a data class. It seems like the @field bit means that Kotlin applies the constraint to the field definitions as we would have in Java