### PR TITLE
🚩 PIC-1772: Disable poddisruptionbudget in k8s temporarily

### DIFF
--- a/helm_deploy/court-hearing-event-receiver/values.yaml
+++ b/helm_deploy/court-hearing-event-receiver/values.yaml
@@ -54,3 +54,6 @@ generic-service:
 generic-prometheus-alerts:
   targetApplication: court-hearing-event-receiver
   alertSeverity: slack-hmpps-user-preferences
+
+poddisruptionbudget:
+  enabled: false


### PR DESCRIPTION
This is a new feature added in generic-service which for now we don't need urgently and it's simpler to disable than fix. I will re-add as part of this ticket but I don't want to leave the build in a broken state whilst I'm away.