### PR TITLE
PIC-4137 Reduce logging of PathNotFoundException to INFO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/CourtHearingEventFieldsFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/web/CourtHearingEventFieldsFilter.kt
@@ -75,7 +75,7 @@ class CourtHearingEventFieldsFilter(
     return try {
       jsonDocument.read(jsonpath)
     } catch (exception: PathNotFoundException) {
-      log.error(exception.message)
+      log.info(exception.message)
       emptyList()
     }
   }


### PR DESCRIPTION
Temporarily downgrade the severity of PathNotFoundException logs to `INFO`

This will help reduce the amount of errors in our logs so that we can release features and tell when something went wrong.

This error occurs even when the requests succeed.

e.g.

`ERROR 1 --- [nio-8080-exec-8] .d.h.c.c.w.CourtHearingEventFieldsFilter : Missing property in path $['hearing']['judiciary']`