### PR TITLE
PIC-4137 Change docker base image to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-slim AS builder
+FROM openjdk:21-jdk-slim-buster AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}


### PR DESCRIPTION
Change docker base image tag to `21-jdk-slim-buster` in order to fix security vulnerabilities that come with 21-slim



21-slim tag has many vulnerabilities

They are relatively the same size images. However, `slim-buster uses Debian-10` vs `slim that uses Debian-12` 

**slim-buster image:** Debian 10 Buster is EoL June 2024 👎🏾 
**slim:** Debian-12 Bookworm has EoL of 2028 👍🏾 

Maybe `21-jdk-slim-buster` has no vunerabilities because it has a debian image that is not being maintained : (

I think I should close this Pull Request. moving to  `21-jdk-slim-buster` may not be a solution
