### PR TITLE
PIC-4134 Update service account name

### DIFF
--- a/helm_deploy/court-hearing-event-receiver/values.yaml
+++ b/helm_deploy/court-hearing-event-receiver/values.yaml
@@ -1,7 +1,7 @@
 generic-service:
   nameOverride: court-hearing-event-receiver
 
-  serviceAccountName: "court-case-service"
+  serviceAccountName: "court-facing-api"
 
   image:
     repository: quay.io/hmpps/court-hearing-event-receiver


### PR DESCRIPTION
Update service account name to court-facing-api which has the correct aws resources access: SNS and S3