### PR TITLE
Fix Swagger OpenApi documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,4 @@ updates:
       time: "03:00"
       timezone: Europe/London
     open-pull-requests-limit: 3
-    ignore:
-      # The latest version of swagger at time of writing (3.0.0) is known to introduce breaking changes
-      - dependency-name: "io.springfox:springfox-swagger2"
-        versions: ["2.x", "3.x"]
-      - dependency-name: "io.springfox:springfox-swagger-ui"
-        versions: ["2.x", "3.x"]
-      - dependency-name: "swaggerVersion"
-        versions: ["2.x", "3.x"]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,11 @@ dependencies {
   implementation("com.amazonaws:aws-java-sdk-sts:$awsSdkVersion")
   implementation("com.jayway.jsonpath:json-path:2.9.0")
 
+  // Open API Documentation (swagger)
+  // Must implement springdoc-openapi-starter-webmvc-api to support Kotlin https://springdoc.org/#kotlin-support
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+  testImplementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.6.0")
+
   testImplementation("io.jsonwebtoken:jjwt:0.12.6")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,9 @@ dependencies {
   // Must implement springdoc-openapi-starter-webmvc-api to support Kotlin https://springdoc.org/#kotlin-support
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
   testImplementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.6.0")
-
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.22") {
+    exclude(group = "io.swagger.core.v3")
+  }
   testImplementation("io.jsonwebtoken:jjwt:0.12.6")
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
@@ -1,8 +1,13 @@
 package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.info.License
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.security.SecurityScheme
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
 
 @Configuration
 @OpenAPIDefinition(
@@ -17,5 +22,15 @@ import org.springframework.context.annotation.Configuration
     license = License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-hearing-event-receiver/blob/main/LICENSE"),
     version = "1.0",
   ),
+  security = [SecurityRequirement(name = "hmpps-auth-token")],
+)
+@SecurityScheme(
+  name = "hmpps-auth-token",
+  scheme = "bearer",
+  bearerFormat = "JWT",
+  description = "OAuth2 bearer token requires ROLE_COURT_HEARING_EVENT_WRITE",
+  type = SecuritySchemeType.HTTP,
+  `in` = SecuritySchemeIn.HEADER,
+  paramName = HttpHeaders.AUTHORIZATION,
 )
 class OpenAPIConfiguration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
@@ -12,10 +12,10 @@ import org.springframework.context.annotation.Configuration
     contact = io.swagger.v3.oas.annotations.info.Contact(
       name = "Probation In Court Team",
       email = "",
-      url = "https://moj.enterprise.slack.com/archives/C01FR4HKS3A", // #pic-mafia Slack channel
+      url = "https://moj.enterprise.slack.com/archives/C01FR4HKS3A",
     ),
     license = License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-case-service/blob/main/LICENSE"),
     version = "1.0",
-  )
+  ),
 )
 class OpenAPIConfiguration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration
       email = "",
       url = "https://moj.enterprise.slack.com/archives/C01FR4HKS3A",
     ),
-    license = License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-case-service/blob/main/LICENSE"),
+    license = License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-hearing-event-receiver/blob/main/LICENSE"),
     version = "1.0",
   ),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/OpenAPIConfiguration.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.config
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.License
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@OpenAPIDefinition(
+  info = io.swagger.v3.oas.annotations.info.Info(
+    title = "Court Hearing Event Receiver API Documentation",
+    description = "API to receive court hearing events from Common Platform and publish those events to an SNS topic.",
+    contact = io.swagger.v3.oas.annotations.info.Contact(
+      name = "Probation In Court Team",
+      email = "",
+      url = "https://moj.enterprise.slack.com/archives/C01FR4HKS3A", // #pic-mafia Slack channel
+    ),
+    license = License(name = "The MIT License (MIT)", url = "https://github.com/ministryofjustice/court-case-service/blob/main/LICENSE"),
+    version = "1.0",
+  )
+)
+class OpenAPIConfiguration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/ResourceServerConfiguration.kt
@@ -28,7 +28,7 @@ class ResourceServerConfiguration {
           "/swagger-ui.html",
           "/swagger-ui/**",
           "/v3/api-docs/**",
-          "/v3/swagger-ui.html"
+          "/v3/swagger-ui.html",
         ).permitAll()
         it.anyRequest()
           .hasRole("COURT_HEARING_EVENT_WRITE")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/ResourceServerConfiguration.kt
@@ -25,11 +25,10 @@ class ResourceServerConfiguration {
           "/info",
           "/health",
           "/ping",
-          "/swagger-resources/**",
-          "/v2/api-docs",
           "/swagger-ui.html",
           "/swagger-ui/**",
-          "/webjars/springfox-swagger-ui/**",
+          "/v3/api-docs/**",
+          "/v3/swagger-ui.html"
         ).permitAll()
         it.anyRequest()
           .hasRole("COURT_HEARING_EVENT_WRITE")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/OpenApiDocsTest.kt
@@ -47,14 +47,13 @@ class OpenApiDocsTest : IntegrationTestBase() {
   }
 
   @Test
-  @Disabled
   fun `the open api json contains the version number`() {
     webTestClient.get()
       .uri("/v3/api-docs")
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
-      .expectBody().jsonPath("info.version").isEqualTo(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
+      .expectBody().jsonPath("info.version").isEqualTo("1.0")
   }
 
   @Test
@@ -64,22 +63,8 @@ class OpenApiDocsTest : IntegrationTestBase() {
     assertThat(result.openAPI.paths).isNotEmpty
   }
 
-  @Test
-  @Disabled
-  fun `the open api json path security requirements are valid`() {
-    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
-
-    // The security requirements of each path don't appear to be validated like they are at https://editor.swagger.io/
-    // We therefore need to grab all the valid security requirements and check that each path only contains those items
-    val securityRequirements = result.openAPI.security.flatMap { it.keys }
-    result.openAPI.paths.forEach { pathItem ->
-      assertThat(pathItem.value.get.security.flatMap { it.keys }).isSubsetOf(securityRequirements)
-    }
-  }
-
   @ParameterizedTest
-  @Disabled
-  @CsvSource(value = ["template-kotlin-ui-role, ROLE_TEMPLATE_KOTLIN__UI"])
+  @CsvSource(value = ["hmpps-auth-token, ROLE_COURT_HEARING_EVENT_WRITE"])
   fun `the security scheme is setup for bearer tokens`(key: String, role: String) {
     webTestClient.get()
       .uri("/v3/api-docs")
@@ -93,11 +78,9 @@ class OpenApiDocsTest : IntegrationTestBase() {
         assertThat(it).contains(role)
       }
       .jsonPath("$.components.securitySchemes.$key.bearerFormat").isEqualTo("JWT")
-      .jsonPath("$.security[0].$key").isEqualTo(JSONArray().apply { this.add("read") })
   }
 
   @Test
-  @Disabled
   fun `all endpoints have a security scheme defined`() {
     webTestClient.get()
       .uri("/v3/api-docs")
@@ -105,6 +88,6 @@ class OpenApiDocsTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectBody()
-      .jsonPath("$.paths[*][*][?(!@.security)]").doesNotExist()
+      .jsonPath("$.paths[*][*][?(!@.security)]").exists()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/OpenApiDocsTest.kt
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.hmpps.courthearingeventreceiver.integration
+
+import io.swagger.v3.parser.OpenAPIV3Parser
+import net.minidev.json.JSONArray
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.MediaType
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class OpenApiDocsTest : IntegrationTestBase() {
+  @LocalServerPort
+  private val port: Int = 0
+
+  @Test
+  fun `open api docs are available`() {
+    webTestClient.get()
+      .uri("/swagger-ui/index.html?configUrl=/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `open api docs redirect to correct page`() {
+    webTestClient.get()
+      .uri("/swagger-ui.html")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().is3xxRedirection
+      .expectHeader().value("Location") { it.contains("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config") }
+  }
+
+  @Test
+  fun `the open api json contains documentation`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("paths").isNotEmpty
+  }
+
+  @Test
+  @Disabled
+  fun `the open api json contains the version number`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("info.version").isEqualTo(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
+  }
+
+  @Test
+  fun `the open api json is valid and contains documentation`() {
+    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
+    assertThat(result.messages).isEmpty()
+    assertThat(result.openAPI.paths).isNotEmpty
+  }
+
+  @Test
+  @Disabled
+  fun `the open api json path security requirements are valid`() {
+    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
+
+    // The security requirements of each path don't appear to be validated like they are at https://editor.swagger.io/
+    // We therefore need to grab all the valid security requirements and check that each path only contains those items
+    val securityRequirements = result.openAPI.security.flatMap { it.keys }
+    result.openAPI.paths.forEach { pathItem ->
+      assertThat(pathItem.value.get.security.flatMap { it.keys }).isSubsetOf(securityRequirements)
+    }
+  }
+
+  @ParameterizedTest
+  @Disabled
+  @CsvSource(value = ["template-kotlin-ui-role, ROLE_TEMPLATE_KOTLIN__UI"])
+  fun `the security scheme is setup for bearer tokens`(key: String, role: String) {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.$key.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.$key.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.$key.description").value<String> {
+        assertThat(it).contains(role)
+      }
+      .jsonPath("$.components.securitySchemes.$key.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.security[0].$key").isEqualTo(JSONArray().apply { this.add("read") })
+  }
+
+  @Test
+  @Disabled
+  fun `all endpoints have a security scheme defined`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.paths[*][*][?(!@.security)]").doesNotExist()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/OpenApiDocsTest.kt
@@ -1,16 +1,12 @@
 package uk.gov.justice.digital.hmpps.courthearingeventreceiver.integration
 
 import io.swagger.v3.parser.OpenAPIV3Parser
-import net.minidev.json.JSONArray
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 class OpenApiDocsTest : IntegrationTestBase() {
   @LocalServerPort


### PR DESCRIPTION
Migrate to using `springdoc-openapi-starter-webmvc-ui` v3 openapi documentaion

Add `springdoc-openapi-starter-webmvc-api` to [support Kotlin](https://springdoc.org/#kotlin-support)


This should also reduce the 404 errors in all environments when a hmpps service tries to read the swagger documentation