### PR TITLE
PIC-4365 Publish messages to AWS FIFO topic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.1.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.2.1")
 
   implementation("com.amazonaws:aws-java-sdk-s3:$awsSdkVersion")
   implementation("com.amazonaws:aws-java-sdk-sts:$awsSdkVersion")

--- a/helm_deploy/court-hearing-event-receiver/values.yaml
+++ b/helm_deploy/court-hearing-event-receiver/values.yaml
@@ -38,8 +38,8 @@ generic-service:
   namespace_secrets:
     court-hearing-event-receiver:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
-    court-case-events-topic:
-      HMPPS_SQS_TOPICS_COURTCASEEVENTSTOPIC_ARN: topic_arn
+    court-cases-topic:
+      HMPPS_SQS_TOPICS_COURTCASESTOPIC_ARN: topic_arn
     crime-portal-gateway-s3-credentials:
       aws_s3_bucket_name: bucket_name
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/service/MessageNotifier.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.hmpps.sqs.MissingTopicException
 import uk.gov.justice.hmpps.sqs.publish
 
 private const val MESSAGE_TYPE = "COMMON_PLATFORM_HEARING"
+private const val MESSAGE_GROUP_ID = "COURT_HEARING_EVENT_RECEIVER"
 
 @Component
 class MessageNotifier(
@@ -18,7 +19,7 @@ class MessageNotifier(
   private val hmppsQueueService: HmppsQueueService,
 ) {
   private val topic =
-    hmppsQueueService.findByTopicId("courtcaseeventstopic")
+    hmppsQueueService.findByTopicId("courtcasestopic")
       ?: throw MissingTopicException("Could not find topic ")
   fun send(hearingEventType: HearingEventType, hearingEvent: HearingEvent) {
     val messageTypeValue =
@@ -33,7 +34,7 @@ class MessageNotifier(
         .stringValue(hearingEventType.description)
         .build()
 
-    val publishResult = topic.publish(eventType = "commonplatform.case.received", event = objectMapper.writeValueAsString(hearingEvent), attributes = mapOf("messageType" to messageTypeValue, "hearingEventType" to hearingEventTypeValue))
+    val publishResult = topic.publish(eventType = "commonplatform.case.received", event = objectMapper.writeValueAsString(hearingEvent), attributes = mapOf("messageType" to messageTypeValue, "hearingEventType" to hearingEventTypeValue), messageGroupId = MESSAGE_GROUP_ID)
     log.info("Published message with message Id {}", publishResult.messageId())
   }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,14 +5,14 @@ hmpps.sqs:
   enabled: true
   provider: localstack
   queues:
-    courtcaseeventsqueue:
-      queueName: court_case_events_queue
-      subscribeTopicId: courtcaseeventstopic
-      dlqName: cpr_court_case_events_queue_dlq
+    courtcasesqueue:
+      queueName: court_cases_queue.fifo
+      subscribeTopicId: courtcasestopic
+      dlqName: court_cases_queue_dlq.fifo
       dlqMaxReceiveCount: 1
   topics:
-    courtcaseeventstopic:
-      arn: "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+    courtcasestopic:
+      arn: "arn:aws:sns:eu-west-2:000000000000:court-cases-topic.fifo"
 
 # Localstack settings
 aws:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
@@ -142,7 +142,7 @@ class EventControllerIntTest : IntegrationTestBase() {
   @Nested
   inner class DeleteEndpoint {
     @Test
-    fun whenPostToHearingDeleteEndpointWithRequiredRole_thenReturn200NoContent_andPushToTopic() {
+    fun whenPostToHearingDeleteEndpointWithRequiredRole_thenReturn200NoContent_andDoNotPushToTopic() {
       deleteEvent(
         jwtHelper.createJwt("common-platform-events", roles = listOf("ROLE_COURT_HEARING_EVENT_WRITE")),
         hearingEvent.hearing.id,
@@ -151,6 +151,9 @@ class EventControllerIntTest : IntegrationTestBase() {
         .expectStatus().isOk
 
       // TODO - when we understand the nature of the DELETE message to be posted, then verify the SNS posting
+
+      val messages = courtCaseEventsQueue?.sqsClient?.receiveMessage(ReceiveMessageRequest.builder().queueUrl(courtCaseEventsQueue?.queueUrl!!).build())!!.get()
+      assertThat(messages.messages().size).isEqualTo(0)
 
       val expectedMap = mapOf("id" to "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2")
       verify(telemetryService).trackEvent(TelemetryEventType.COURT_HEARING_DELETE_EVENT_RECEIVED, expectedMap)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
@@ -3,21 +3,25 @@ package uk.gov.justice.digital.hmpps.courthearingeventreceiver.controller
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import reactor.core.publisher.Mono
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.HearingEvent
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.model.type.HearingEventType
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryEventType
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.service.TelemetryService
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.io.File
 
 @ActiveProfiles("test")
@@ -33,6 +37,7 @@ class EventControllerIntTest : IntegrationTestBase() {
 
   @BeforeEach
   override fun beforeEach() {
+    courtCasesQueue?.sqsClient?.purgeQueue(PurgeQueueRequest.builder().queueUrl(courtCasesQueue!!.queueUrl).build())
     val str = File("src/test/resources/json/court-application-minimal.json").readText(Charsets.UTF_8)
     hearingEvent = objectMapper.readValue(str, HearingEvent::class.java)
   }
@@ -49,7 +54,7 @@ class EventControllerIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      val messages = courtCaseEventsQueue?.sqsClient?.receiveMessage(ReceiveMessageRequest.builder().queueUrl(courtCaseEventsQueue?.queueUrl!!).build())!!.get()
+      val messages = courtCasesQueue?.sqsClient?.receiveMessage(ReceiveMessageRequest.builder().queueUrl(courtCasesQueue?.queueUrl!!).build())!!.get()
       assertThat(messages.messages().size).isEqualTo(1)
       val message: SQSMessage = objectMapper.readValue(messages.messages()[0].body(), SQSMessage::class.java)
 
@@ -70,6 +75,47 @@ class EventControllerIntTest : IntegrationTestBase() {
         "caseUrn" to "80GD8183221",
       )
       verify(telemetryService).trackEvent(TelemetryEventType.COURT_HEARING_UPDATE_EVENT_RECEIVED, expectedMap)
+    }
+
+    @Test
+    fun whenDuplicatePostToEventEndpointWithRequiredRole_thenReturn200NoContent_andPushToTopic_and1MessageOnQueue() {
+      postEvent(
+        hearingEvent,
+        jwtHelper.createJwt("common-platform-events", roles = listOf("ROLE_COURT_HEARING_EVENT_WRITE")),
+      )
+        .exchange()
+        .expectStatus().isOk
+
+      postEvent(
+        hearingEvent,
+        jwtHelper.createJwt("common-platform-events", roles = listOf("ROLE_COURT_HEARING_EVENT_WRITE")),
+      )
+        .exchange()
+        .expectStatus().isOk
+
+      await().until { countMessagesOnQueue() == 1 }
+
+      val messages = courtCasesQueue?.sqsClient?.receiveMessage(ReceiveMessageRequest.builder().queueUrl(courtCasesQueue?.queueUrl!!).build())!!.get()
+
+      val message: SQSMessage = objectMapper.readValue(messages.messages()[0].body(), SQSMessage::class.java)
+
+      assertThat(message.message).contains("59cb14a6-e8de-4615-9c9d-94fa5ef81ad2") // this is the hearing ID
+      assertThat(message.message).contains("Adjournment")
+      assertThat(message.message).contains("isYouth")
+      assertThat(message.message).contains("\"lja\":{\"ljaCode\":\"2577\",\"ljaName\":\"South West London Magistrates' Court\"}}")
+      assertThat(message.message).contains("\"judicialResultPrompts\":[{\"courtExtract\":\"Y\",\"isDurationEndDate\":true,\"isFinancialImposition\":false,\"judicialResultPromptTypeId\":\"20fe3e69-c7d6-4f72-8b77-13c70c1f986d\",\"label\":\"Number of days to abstain from consuming any alcohol\",\"promptReference\":\"numberOfDaysToAbstainFromConsumingAnyAlcohol\",\"promptSequence\":100,\"type\":\"INT\",\"value\":\"120\"}]}]")
+      assertThat(message.messageAttributes.messageType.type).isEqualTo("String")
+      assertThat(message.messageAttributes.messageType.value).isEqualTo("COMMON_PLATFORM_HEARING")
+
+      assertThat(message.messageAttributes.hearingEventType.value).isEqualTo(HearingEventType.CONFIRMED_OR_UPDATED.description)
+
+      val expectedMap = mapOf(
+        "courtCode" to "B10JQ",
+        "hearingId" to "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2",
+        "caseId" to "1d1861ed-e18c-429d-bad0-671802f9cdba",
+        "caseUrn" to "80GD8183221",
+      )
+      verify(telemetryService, times(2)).trackEvent(TelemetryEventType.COURT_HEARING_UPDATE_EVENT_RECEIVED, expectedMap)
     }
 
     @Test
@@ -100,7 +146,7 @@ class EventControllerIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      val messages = courtCaseEventsQueue?.sqsClient?.receiveMessage(ReceiveMessageRequest.builder().queueUrl(courtCaseEventsQueue?.queueUrl!!).build())!!.get()
+      val messages = courtCasesQueue?.sqsClient?.receiveMessage(ReceiveMessageRequest.builder().queueUrl(courtCasesQueue?.queueUrl!!).build())!!.get()
       assertThat(messages.messages().size).isEqualTo(1)
       val message: SQSMessage = objectMapper.readValue(messages.messages()[0].body(), SQSMessage::class.java)
 
@@ -152,8 +198,8 @@ class EventControllerIntTest : IntegrationTestBase() {
 
       // TODO - when we understand the nature of the DELETE message to be posted, then verify the SNS posting
 
-      val messages = courtCaseEventsQueue?.sqsClient?.receiveMessage(ReceiveMessageRequest.builder().queueUrl(courtCaseEventsQueue?.queueUrl!!).build())!!.get()
-      assertThat(messages.messages().size).isEqualTo(0)
+      val messagesCount = courtCasesQueue?.sqsClient?.countMessagesOnQueue(courtCasesQueue?.queueUrl!!)!!.get()
+      assertThat(messagesCount).isEqualTo(0)
 
       val expectedMap = mapOf("id" to "59cb14a6-e8de-4615-9c9d-94fa5ef81ad2")
       verify(telemetryService).trackEvent(TelemetryEventType.COURT_HEARING_DELETE_EVENT_RECEIVED, expectedMap)
@@ -213,6 +259,8 @@ class EventControllerIntTest : IntegrationTestBase() {
         .expectStatus().isBadRequest
     }
   }
+
+  private fun countMessagesOnQueue() = courtCasesQueue?.sqsClient?.countMessagesOnQueue(courtCasesQueue?.queueUrl!!)!!.get()
 
   private fun postEvent(hearingEvent: HearingEvent, token: String, pathFormat: String = UPDATE_PATH) =
     webTestClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/controller/EventControllerIntTest.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import reactor.core.publisher.Mono
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.courthearingeventreceiver.integration.IntegrationTestBase
@@ -115,6 +116,10 @@ class EventControllerIntTest : IntegrationTestBase() {
         "caseId" to "1d1861ed-e18c-429d-bad0-671802f9cdba",
         "caseUrn" to "80GD8183221",
       )
+
+      courtCasesQueue?.sqsClient?.deleteMessage(DeleteMessageRequest.builder().queueUrl(courtCasesQueue?.queueUrl!!).receiptHandle(messages.messages()[0].receiptHandle()).build())
+
+      await().until { countMessagesOnQueue() == 0 }
       verify(telemetryService, times(2)).trackEvent(TelemetryEventType.COURT_HEARING_UPDATE_EVENT_RECEIVED, expectedMap)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/integration/IntegrationTestBase.kt
@@ -35,14 +35,14 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var hmppsQueueService: HmppsQueueService
-  val courtCaseEventsQueue by lazy {
-    hmppsQueueService.findByQueueId("courtcaseeventsqueue")
+  val courtCasesQueue by lazy {
+    hmppsQueueService.findByQueueId("courtcasesqueue")
   }
 
   @BeforeEach
   fun beforeEach() {
-    courtCaseEventsQueue!!.sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(courtCaseEventsQueue!!.queueUrl).build())
-    courtCaseEventsQueue!!.sqsDlqClient?.purgeQueue(PurgeQueueRequest.builder().queueUrl(courtCaseEventsQueue!!.dlqUrl).build())
+    courtCasesQueue!!.sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(courtCasesQueue!!.queueUrl).build())
+    courtCasesQueue!!.sqsDlqClient?.purgeQueue(PurgeQueueRequest.builder().queueUrl(courtCasesQueue!!.dlqUrl).build())
   }
 
   @TestConfiguration

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,14 +9,14 @@ hmpps.sqs:
   enabled: true
   provider: localstack
   queues:
-    courtcaseeventsqueue:
-      queueName: court_case_events_queue
-      subscribeTopicId: courtcaseeventstopic
-      dlqName: cpr_court_case_events_queue_dlq
+    courtcasesqueue:
+      queueName: court_cases_queue.fifo
+      subscribeTopicId: courtcasestopic
+      dlqName: court_cases_queue_dlq.fifo
       dlqMaxReceiveCount: 1
   topics:
-    courtcaseeventstopic:
-      arn: "arn:aws:sns:eu-west-2:000000000000:court-case-events-topic"
+    courtcasestopic:
+      arn: "arn:aws:sns:eu-west-2:000000000000:court-cases-topic.fifo"
 
 # Localstack settings
 aws:


### PR DESCRIPTION
Update to send message to SNS FIFO topic 

Upgrade `uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter` to `5.2.1`

v5.2.1 has the update to the HMPPSTopic.publish method to allow for the MessageGroupID to be passed in. MessageGroupID is a required key/value when sending message to a FIFO topic.

Update the local-stack sns and sqs resources to FIFO.