### PR TITLE
PIC-4424 Fix the s3bucket env name

### DIFF
--- a/helm_deploy/court-hearing-event-receiver/values.yaml
+++ b/helm_deploy/court-hearing-event-receiver/values.yaml
@@ -43,7 +43,7 @@ generic-service:
     crime-portal-gateway-s3-credentials:
       aws_s3_bucket_name: bucket_name
     large-court-cases-s3-credentials:
-      AWS_S3_LARGECASES_BUCKETNAME: bucket_name
+      AWS_S3_LARGE_CASES_BUCKET_NAME: bucket_name
 
   allowlist:
     groups:


### PR DESCRIPTION
Fix the s3bucket env name to resemble `aws.s3.large_cases.bucket_name` in the application properties file.