### PR TITLE
Remove health endpoint from allowlist

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/courthearingeventreceiver/config/ResourceServerConfiguration.kt
@@ -24,9 +24,7 @@ class ResourceServerConfiguration {
       }
       .authorizeHttpRequests {
         it.requestMatchers(
-          "/health/**",
           "/info",
-          "/health",
           "/ping",
           "/swagger-ui.html",
           "/swagger-ui/**",


### PR DESCRIPTION
temporarily remove /health from allow group.

so we can test authentication and see if common platform can make a call to the /health endpoint